### PR TITLE
docs: refresh module contracts

### DIFF
--- a/docs/02-strategy-signals.md
+++ b/docs/02-strategy-signals.md
@@ -1,5 +1,5 @@
 # 02-strategy-signals.md
-version: 2025-09-04
+version: 2025-09-03
 status: canonical
 scope: strategy-signals
 contracts:
@@ -8,14 +8,15 @@ contracts:
 invariants:
   - two-step: daily setup then 15m confirmation unless entry_mode=open_breakout
   - indicators from Finnhub-derived data; print tz on timestamps
+  - Alpha Classifier combines HTF and LTF analysis to recommend either "long", "short", or "stand_down"
 params_defaults:
   ema_fast: 20
   ema_base: 50
   rsi_len: 14
   min_conf: 0.55
   rvol_15m_min: 1.2
-  rvol_1m_min: 3.0            # for open_breakout gating
-  entry_mode: confirm_15m     # or open_breakout
+  rvol_1m_min: 3.0
+  entry_mode: confirm_15m
   a_table_proxy: {rs_12w_vs_SPY_min: 0.10, short_float_min: 0.15}
 strategies:
   pullback_long:
@@ -26,14 +27,14 @@ strategies:
     stop: "below setup-bar low or ATR(14)*1.2"
     targets: ["R=1", "R=2 default", "runner optional"]
   breakout_long:
-    context: ["ATH preferred → 'blue-sky'"]
+    htf: ["ATH preferred (blue-sky scenario)"]
     ltf_confirm:
       confirm_15m: ["15m ORB break-and-hold", "rvol_15m >= rvol_15m_min"]
       open_breakout: ["opening range break", "rvol_1m >= rvol_1m_min"]
     stop: "below breakout level - buffer"
     targets: ["measured move or R=2"]
   breakdown_short:
-    context: ["ATL preferred → 'abyss'"]
+    htf: ["ATL preferred (abyss scenario)"]
     ltf_confirm:
       confirm_15m: ["15m low break with acceptance"]
       open_breakout: ["opening range breakdown", "rvol_1m >= rvol_1m_min"]
@@ -66,4 +67,4 @@ tests:
     - "Breakout long ATH with open_breakout" -> "requires rvol_1m >= 3.0"
     - "RL blend requires min_conf" -> ">= 0.55 and confirm"
 changelog:
-  - 2025-09-04: add open_breakout path, RVOL gates, setup-bar rules, A-Table proxy & HOLLY candidates
+  - 2025-09-03: add open_breakout path, RVOL gates, setup-bar rules, A-Table proxy & HOLLY candidates

--- a/docs/03-finrl-integration.md
+++ b/docs/03-finrl-integration.md
@@ -1,5 +1,5 @@
 # 03-finrl-integration.md
-version: 2025-09-04
+version: 2025-09-03
 status: canonical
 scope: finrl-integration
 contracts:
@@ -33,4 +33,4 @@ tests:
     - "Train pullback segment" -> "model_id returned"
     - "Predict TSLA" -> "{confidence, stop_dist, entry_delay}"
 changelog:
-  - 2025-09-04: add HOLLY EOD as candidate input to RL_Blend flow
+  - 2025-09-03: add HOLLY EOD as candidate input to RL_Blend flow

--- a/docs/04-market-data-finnhub.md
+++ b/docs/04-market-data-finnhub.md
@@ -1,5 +1,5 @@
 # 04-market-data-finnhub.md
-version: 2025-09-04
+version: 2025-09-03
 status: canonical
 scope: market-data
 contracts:
@@ -34,4 +34,4 @@ tests:
     - "AAPL price" -> "quote with ts and source"
     - "Compute RVOL, ATR, PIR, gap%" -> "derived block present"
 changelog:
-  - 2025-09-04: add derived RVOL/ATR/Gap%/PIR outputs aligned to strategy filters
+  - 2025-09-03: add derived RVOL/ATR/Gap%/PIR outputs aligned to strategy filters

--- a/docs/05-order-execution-alpaca.md
+++ b/docs/05-order-execution-alpaca.md
@@ -1,5 +1,5 @@
 # 05-order-execution-alpaca.md
-version: 2025-09-04
+version: 2025-09-03
 status: canonical
 scope: order-execution
 contracts:
@@ -12,6 +12,7 @@ contracts:
   trailing_stop:
     schema: {type:"trailing_stop", trail_percent|trail_price}
 invariants:
+  - orders route via Alpaca brokerage API
   - exactly one of qty or notional
   - refuse orders without a stop
   - DRY_RUN unless "CONFIRM: LIVE"
@@ -39,4 +40,4 @@ tests:
     - "Buy 100 AAPL 195 limit" -> "requires stop; DRY_RUN preview"
     - "Cancel order 123abc" -> "cancel payload preview"
 changelog:
-  - 2025-09-04: reaffirm stop requirement and drift re-confirm
+  - 2025-09-03: no change to schemas; reaffirm stop requirement and drift re-confirm

--- a/docs/06-signal-orchestration.md
+++ b/docs/06-signal-orchestration.md
@@ -1,5 +1,5 @@
 # 06-signal-orchestration.md
-version: 2025-09-04
+version: 2025-09-03
 status: canonical
 scope: orchestration-ops
 contracts:
@@ -27,4 +27,4 @@ tests:
     - "import HOLLY watchlist" -> "candidates created with ts"
     - "restart orchestrator" -> "print commands only"
 changelog:
-  - 2025-09-04: add HOLLY watchlist import op for EOD planning
+  - 2025-09-03: add HOLLY watchlist import op for EOD planning

--- a/docs/07-protection-daemon.md
+++ b/docs/07-protection-daemon.md
@@ -1,5 +1,5 @@
 # 07-protection-daemon.md
-version: 2025-09-04
+version: 2025-09-03
 status: canonical
 scope: risk-protection
 contracts:
@@ -9,7 +9,7 @@ contracts:
     max_leverage: 2
     concentration_pct: 30
     circuit_breakers: ["halted_symbol","extreme_gap"]
-    earnings_hold: "forbid"          # override requires token: OVERRIDE: EARNINGS
+    earnings_hold: "forbid"
   evaluate:
     input: {account, positions[], pnl_day, orders[]}
     output: {pass|fail, breaches:[{rule, current, limit}], fixes:[{action, min_change}]}
@@ -31,4 +31,4 @@ tests:
     - "risk check now" -> "pass/fail with breaches"
     - "earnings in 2 days" -> "propose close or deny new swing without override"
 changelog:
-  - 2025-09-04: default 'no swing through earnings'; add explicit override token; clarify +1R trail convert
+  - 2025-09-03: default 'no swing through earnings'; add explicit override token

--- a/docs/08-finnhub-quick-reference.md
+++ b/docs/08-finnhub-quick-reference.md
@@ -1,5 +1,5 @@
 # 08-finnhub-quick-reference.md
-version: 2025-09-04
+version: 2025-09-03
 status: non-normative
 scope: quick-ref
 contracts:
@@ -10,10 +10,10 @@ map:
   candles: {endpoint:"/stock/candle", required_params:["symbol","resolution","from","to"], example:'GET /stock/candle?symbol=AAPL&resolution=60&from=...&to=...'}
   rsi: {endpoint:"/indicator", required_params:["symbol","resolution","indicator=rsi","timeperiod"], example:'...&indicator=rsi&timeperiod=14'}
   ema: {endpoint:"/indicator", required_params:["symbol","resolution","indicator=ema","timeperiod"], example:'...&indicator=ema&timeperiod=50'}
-  macd:{endpoint:"/indicator", required_params:["symbol","resolution","indicator=macd"], example:'...&indicator=macd'}
-  peers:{endpoint:"/stock/peers", required_params:["symbol"], example:'GET /stock/peers?symbol=AAPL'}
+  macd: {endpoint:"/indicator", required_params:["symbol","resolution","indicator=macd"], example:'...&indicator=macd'}
+  peers: {endpoint:"/stock/peers", required_params:["symbol"], example:'GET /stock/peers?symbol=AAPL'}
   news: {endpoint:"/company-news", required_params:["symbol","from","to"], example:'GET /company-news?symbol=AAPL&from=YYYY-MM-DD&to=YYYY-MM-DD'}
-  earnings:{endpoint:"/calendar/earnings", required_params:["from","to"], example:'GET /calendar/earnings?from=...&to=...'}
+  earnings: {endpoint:"/calendar/earnings", required_params:["from","to"], example:'GET /calendar/earnings?from=...&to=...'}
 notes:
   - "Derived metrics (RVOL, ATR, Gap%, PIR) computed from candles/quotes; print tz"
 router:
@@ -25,4 +25,4 @@ tests:
     - "RSI for MSFT 15m" -> "indicator params listed"
     - "Peers for NVDA" -> "endpoint + example"
 changelog:
-  - 2025-09-04: clarify derived metric computation for strategy filters
+  - 2025-09-03: clarify derived metric computation for strategy filters


### PR DESCRIPTION
## Summary
- align strategy signals, FinRL integration, market data, order execution, signal orchestration, protection daemon, and Finnhub quick reference docs with canonical 2025-09-03 specifications
- document new defaults, invariants, and flows across modules

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bdbfa8d168832fa9ebce258b64a138