### PR TITLE
docs: update alpha router specs

### DIFF
--- a/00-router-overlay.md
+++ b/00-router-overlay.md
@@ -1,0 +1,6 @@
+prechecks:
+  session_open_or_ext: "If closed, report next session; extended-hours allowed if specified."
+nodes:
+  place_order: {triggers:["buy","sell","short","limit","stop","bracket","oco"], pre:["symbol_tradable","session_open_or_ext","risk_limits","buying_power","position_sizing","duplicate_order"], action:"Build payload. DRY_RUN unless live token. Refuse if no stop."}
+batch_screen:
+  output_table_cols: [symbol, close, sma50, atr, pir_5d_pct, rvol15, candidates, confirm]

--- a/alpaca/common/utils.py
+++ b/alpaca/common/utils.py
@@ -33,7 +33,7 @@ def validate_uuid_id_param(
 
 
 def validate_symbol_or_asset_id(
-    symbol_or_asset_id: Union[UUID, str]
+    symbol_or_asset_id: Union[UUID, str],
 ) -> Union[UUID, str]:
     """
     A helper function to eliminate duplicate checks of symbols or asset ids.
@@ -55,7 +55,7 @@ def validate_symbol_or_asset_id(
 
 
 def validate_symbol_or_contract_id(
-    symbol_or_contract_id: Union[UUID, str]
+    symbol_or_contract_id: Union[UUID, str],
 ) -> Union[UUID, str]:
     """
     A helper function to eliminate duplicate checks of symbols or contract id.

--- a/alpha-classifier-contract.md
+++ b/alpha-classifier-contract.md
@@ -1,0 +1,6 @@
+## Output
+class: enum { long | short | neutral }
+
+rationale?: string
+
+*Note:* In the context of Alpha's strategy modules, a `neutral` class indicates a `stand_down` signal. This mapping ensures consistency between the classifier and the strategy definitions.

--- a/alpha-router-overlay.md
+++ b/alpha-router-overlay.md
@@ -1,0 +1,8 @@
+prechecks:
+  session_open_or_ext: "If closed, report next session with tz; extended-hours allowed if specified."
+batch_screen:
+  output_table_cols: ["symbol","close","sma50","atr","pir_5d_pct","rvol15","candidates","confirm"]
+  confirmation_gate:
+    rvol15_min: 1.2
+  # Map classifier neutral output to stand_down for strategy modules
+  neutral_label: "stand_down"


### PR DESCRIPTION
## Summary
- document extended hours and neutral label in alpha router overlays
- clarify neutral classifier mapping to stand_down
- format utils for pre-commit compliance

## Testing
- `pre-commit run --files 00-router-overlay.md alpha-router-overlay.md alpha-classifier-contract.md alpaca/common/utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68bdca9e5668832f9fb27bb94bb88a7f