### PR TITLE
docs: add Alpaca reference notes

### DIFF
--- a/docs/alpaca/09-alpaca-urls-auth.md
+++ b/docs/alpaca/09-alpaca-urls-auth.md
@@ -1,0 +1,57 @@
+# 09-alpaca-urls-auth.md
+version: 2025-09-08
+status: canonical
+scope: alpaca/urls-auth
+
+## REST base URLs
+- Live Trading: [https://api.alpaca.markets](https://api.alpaca.markets)
+- Paper Trading: [https://paper-api.alpaca.markets](https://paper-api.alpaca.markets)
+- Market Data (HTTP): [https://data.alpaca.markets](https://data.alpaca.markets)
+
+## Auth (HTTP)
+Send headers on every private request:
+- APCA-API-KEY-ID: <key_id>
+- APCA-API-SECRET-KEY: <secret_key>
+
+### Quick test
+GET https://{api|paper-api}.alpaca.markets/v2/account
+
+## Trading WebSocket (account & order updates)
+- wss://api.alpaca.markets/stream  (live)
+- wss://paper-api.alpaca.markets/stream  (paper)
+
+Authenticate after connect:
+```json
+{"action":"auth","key":"<KEY_ID>","secret":"<SECRET>"}
+```
+
+Subscribe:
+```json
+{"action":"listen","data":{"streams":["trade_updates"]}}
+```
+
+## Market Data WebSocket
+URL schema:
+- wss://stream.data.alpaca.markets/{version}/{feed}
+- Feeds: v2/sip, v2/iex, v2/delayed_sip, v1beta1/boats, v1beta1/overnight
+
+Auth options:
+- HTTP headers: APCA-API-KEY-ID / APCA-API-SECRET-KEY
+- Or message:
+```json
+{"action":"auth","key":"<KEY_ID>","secret":"<SECRET>"}
+```
+
+Subscribe example:
+```json
+{"action":"subscribe","trades":["AAPL"],"quotes":["AAPL"],"bars":["AAPL"]}
+```
+
+## Notes
+- Paper and live use different domains and different credentials. Verify before sending orders.
+
+Sources:
+- https://docs.alpaca.markets/docs/authentication-1
+- https://docs.alpaca.markets/docs/websocket-streaming
+- https://docs.alpaca.markets/docs/streaming-market-data
+- https://docs.alpaca.markets/docs/real-time-stock-pricing-data

--- a/docs/alpaca/10-alpaca-rate-limits-and-retries.md
+++ b/docs/alpaca/10-alpaca-rate-limits-and-retries.md
@@ -1,0 +1,39 @@
+# 10-alpaca-rate-limits-and-retries.md
+version: 2025-09-08
+status: canonical
+scope: alpaca/rate-limits
+
+## HTTP rate-limit signals
+Read these response headers and pace requests:
+- X-RateLimit-Limit
+- X-RateLimit-Remaining
+- X-RateLimit-Reset  (Unix epoch when quota resets)
+
+### 429 handling
+- Treat as “Too Many Requests”.
+- Sleep until X-RateLimit-Reset, then retry with jitter.
+- Keep per-endpoint budgets.
+
+## Market Data plan RPM (historical API)
+- Basic: 200 requests/min
+- Algo Trader Plus: 10,000 requests/min
+
+## WebSocket limits
+- Most subscriptions allow 1 active connection per endpoint. Second connection returns:
+
+* * code: 406
+* * msg: "connection limit exceeded"
+*
+
+## Backoff recipe
+1) Track Remaining/Reset per token + host.
+2) If Remaining <= 1, pause until Reset + random(50–200ms).
+3) On 429, exponential backoff starting at Reset or 1s, max 60s.
+
+## Monitor
+- Log 429s, Reset deltas, and reconnect causes.
+
+Sources:
+- https://docs.alpaca.markets
+- https://docs.alpaca.markets/docs/market-data-api
+- https://docs.alpaca.markets/docs/streaming-market-data

--- a/docs/alpaca/11-alpaca-orders-quickref.md
+++ b/docs/alpaca/11-alpaca-orders-quickref.md
@@ -1,0 +1,59 @@
+# 11-alpaca-orders-quickref.md
+version: 2025-09-08
+status: canonical
+scope: alpaca/orders
+
+## Core fields
+symbol, side, qty|notional, type, time_in_force, limit_price?, stop_price?, extended_hours?, client_order_id?
+
+## Equities (whole shares)
+- Types: market, limit, stop, stop_limit
+- TIF: day, gtc (ioc/fok/opg/cls *by arrangement*)
+- Sub-penny rule for limits: ≥$1 → 2 decimals; <$1 → 4 decimals
+
+## Equities (fractional)
+- TIF: day only
+- Types allowed with day: market, limit, stop, stop_limit
+
+## Extended-hours (equities)
+- Allowed only with limit + time_in_force=day + extended_hours=true
+- Brackets not supported in extended hours
+
+## Crypto
+- Types: market, limit, stop_limit
+- TIF: gtc, ioc
+
+## Options
+- Types: market, limit
+- TIF: day only
+- No extended hours
+
+## OTC assets
+- Types: market, limit, stop, stop_limit
+- TIF: day, gtc
+
+## Bracket / OCO / OTO
+- bracket: order_class="bracket", take_profit.limit_price, stop_loss.stop_price
+- oco: order_class="oco"
+- Extended hours: not supported
+- TIF: day or gtc
+
+## Trailing stop
+- type="trailing_stop", trail_percent|trail_price
+- Does not trigger outside regular hours
+- TIF: day or gtc
+
+### Example (equity bracket)
+```json
+{
+  "symbol":"AAPL","side":"buy","qty":"10","type":"limit","time_in_force":"day","limit_price":"195",
+  "order_class":"bracket",
+  "take_profit":{"limit_price":"199"},
+  "stop_loss":{"stop_price":"191"}
+}
+```
+
+Sources:
+- https://docs.alpaca.markets/docs/orders-at-alpaca
+- https://docs.alpaca.markets/reference/createorderforaccount
+- https://docs.alpaca.markets/docs/options-trading-overview

--- a/docs/alpaca/12-alpaca-gtc-policy.md
+++ b/docs/alpaca/12-alpaca-gtc-policy.md
@@ -1,0 +1,20 @@
+# 12-alpaca-gtc-policy.md
+version: 2025-09-08
+status: canonical
+scope: alpaca/gtc
+
+## GTC aging
+- Alpaca auto-cancels GTC orders 90 days after creation.
+- See `expires_at` on order objects.
+- Cancel job runs on the `expires_at` date at 4:15 pm ET; order may show `pending_cancel` until venue confirms.
+
+## What to do
+- Read `expires_at` when placing orders.
+- Re-issue long-lived GTC instructions before expiration if still desired.
+- Journal the new client_order_id when re-placing.
+
+## Affects
+- Applies to single, bracket, OCO, and stop orders placed with GTC.
+
+Sources:
+- https://docs.alpaca.markets/docs/orders-at-alpaca

--- a/docs/alpaca/13-alpaca-idempotency.md
+++ b/docs/alpaca/13-alpaca-idempotency.md
@@ -1,0 +1,37 @@
+# 13-alpaca-idempotency.md
+version: 2025-09-08
+status: canonical
+scope: alpaca/idempotency
+
+## Use client_order_id
+- Provide `client_order_id` (≤128 chars) on POST /v2/orders.
+- Retrieve by client id:
+
+* * GET /v2/orders:by_client_order_id?client_order_id=...
+*
+
+## Why
+- Prevent duplicate entries on retries.
+- Correlate fills and updates across services.
+
+## Pattern
+1) Generate UUIDv4 per intent.
+2) POST order with `client_order_id`.
+3) If timeout or 5xx, GET by client id before retrying.
+
+### PowerShell 7
+```powershell
+$cid=[guid]::NewGuid().ToString()
+$body=@{symbol="AAPL";side="buy";qty="1";type="market";time_in_force="day";client_order_id=$cid} | ConvertTo-Json
+Invoke-RestMethod -Method Post -Uri "https://paper-api.alpaca.markets/v2/orders" -Headers @{ "APCA-API-KEY-ID"="$env:ALPACA_KEY"; "APCA-API-SECRET-KEY"="$env:ALPACA_SECRET" } -Body $body -ContentType "application/json"
+# verify
+Invoke-RestMethod -Method Get -Uri "https://paper-api.alpaca.markets/v2/orders:by_client_order_id?client_order_id=$cid" -Headers @{ "APCA-API-KEY-ID"="$env:ALPACA_KEY"; "APCA-API-SECRET-KEY"="$env:ALPACA_SECRET" }
+```
+
+## Replace caveat
+- A successful replace response does not guarantee the original wasn’t filled first; confirm via `trade_updates` stream.
+
+Sources:
+- https://docs.alpaca.markets/reference/getorderbyclientorderid
+- https://docs.alpaca.markets/docs/working-with-orders
+- https://docs.alpaca.markets/reference/replaceorderforaccount-1

--- a/docs/alpaca/14-alpaca-streams.md
+++ b/docs/alpaca/14-alpaca-streams.md
@@ -1,0 +1,44 @@
+# 14-alpaca-streams.md
+version: 2025-09-08
+status: canonical
+scope: alpaca/streams
+
+## Trading stream (orders, fills, account)
+- Endpoints: wss://{api|paper-api}.alpaca.markets/stream
+- Auth message:
+```json
+{"action":"auth","key":"<KEY_ID>","secret":"<SECRET>"}
+```
+- Listen:
+```json
+{"action":"listen","data":{"streams":["trade_updates"]}}
+```
+- Common event values: new, partial_fill, fill, canceled, expired, done_for_day, replaced.
+- Less common: accepted, rejected, pending_new, stopped, pending_cancel, pending_replace, calculated, suspended, order_replace_rejected, order_cancel_rejected.
+
+## Market Data stream
+- Endpoint schema: wss://stream.data.alpaca.markets/{version}/{feed}
+- Feeds: v2/sip, v2/iex, v2/delayed_sip, v1beta1/boats, v1beta1/overnight
+- Auth: headers or message {"action":"auth","key":"...","secret":"..."} within 10s.
+- Subscribe / unsubscribe:
+```json
+{"action":"subscribe","trades":["AAPL"],"quotes":["AAPL"],"bars":["*"]}
+```
+```json
+{"action":"unsubscribe","quotes":["AAPL"]}
+```
+- Test stream: wss://stream.data.alpaca.markets/v2/test  (use symbol FAKEPACA)
+
+## Message format
+- Array of JSON objects. Control messages have `T` in {success, error, subscription}.
+
+## Errors (data WS)
+- 401 not authenticated, 402 auth failed, 404 auth timeout, 405 symbol limit exceeded, 406 connection limit exceeded, 407 slow client, 409 insufficient subscription, 410 invalid subscribe action.
+
+## Notes
+- Paper trading stream may use binary frames. Handle JSON and MessagePack.
+
+Sources:
+- https://docs.alpaca.markets/docs/websocket-streaming
+- https://docs.alpaca.markets/docs/streaming-market-data
+- https://docs.alpaca.markets/docs/real-time-stock-pricing-data

--- a/docs/alpaca/15-alpaca-extended-overnight.md
+++ b/docs/alpaca/15-alpaca-extended-overnight.md
@@ -1,0 +1,30 @@
+# 15-alpaca-extended-overnight.md
+version: 2025-09-08
+status: canonical
+scope: alpaca/extended
+
+## Sessions (equities)
+- Overnight: 8:00 pm – 4:00 am ET, Sun–Fri
+- Pre-market: 4:00 am – 9:30 am ET, Mon–Fri
+- After-hours: 4:00 pm – 8:00 pm ET, Mon–Fri
+
+## How to place extended-hours orders
+- Equities only.
+- Must be: type=limit, time_in_force=day, extended_hours=true.
+
+## Not supported in extended hours
+- Bracket/OCO/OTO legs.
+- Trailing stop triggers.
+
+## Fractional during extended
+- Limit orders in extended hours supported for fractional per platform updates.
+
+## Overnight tradability flags
+- Assets API exposes fields to identify overnight eligibility (e.g., `overnight_tradable`, `overnight_halted`) when overnight trading is enabled.
+
+## Market data for overnight
+- WebSocket feeds include `v1beta1/boats` and `v1beta1/overnight` for overnight prints.
+
+Sources:
+- https://docs.alpaca.markets/docs/extended-hours-trading
+- https://docs.alpaca.markets/docs/real-time-stock-pricing-data

--- a/docs/alpaca/16-alpaca-errors-429.md
+++ b/docs/alpaca/16-alpaca-errors-429.md
@@ -1,0 +1,35 @@
+# 16-alpaca-errors-429.md
+version: 2025-09-08
+status: canonical
+scope: alpaca/errors-429
+
+## What 429 means
+- HTTP 429 = rate limit exceeded. Respect per-endpoint quotas.
+
+## Headers to read
+- X-RateLimit-Limit
+- X-RateLimit-Remaining
+- X-RateLimit-Reset  (Unix epoch when quota resets)
+
+## Minimal handler
+- If Remaining <= 1: wait until Reset + jitter.
+- On 429: sleep(max(Reset-now, 1s)) with exponential backoff, cap 60s, then retry once.
+- Never spam retries across multiple symbols in parallel without tokens.
+
+### Example (pseudo)
+```text
+if resp.status==429:
+  wait = max(resp.headers.Reset - now, 1)
+  sleep(wait + rand(50..200ms))
+  retry()
+```
+
+## WebSocket analog
+- Connection limit errors return `{"T":"error","code":406,"msg":"connection limit exceeded"}`. Close the other session or wait before reconnecting.
+
+## Logging
+- Record endpoint, Remaining, Reset, retry count, and eventual success/fail per request id.
+
+Sources:
+- https://docs.alpaca.markets/docs/streaming-market-data
+- https://docs.alpaca.markets/docs/market-data-api


### PR DESCRIPTION
## Summary
- add docs for Alpaca API base URLs and auth headers
- document rate limits, order types, and GTC aging
- note client_order_id idempotency, streaming endpoints, extended hours, and 429 handling

## Testing
- `make lint`
- `make test` *(fails: ModuleNotFoundError: No module named 'requests_mock')*

------
https://chatgpt.com/codex/tasks/task_e_68bed7cfeb18832faadfeb10bd1e3dff