### PR TITLE
docs: document FinRL actions service

### DIFF
--- a/docs/finrl/01-finrl-urls-auth.md
+++ b/docs/finrl/01-finrl-urls-auth.md
@@ -1,0 +1,24 @@
+# 01-finrl-urls-auth.md
+version: 2025-09-08
+status: canonical
+scope: finrl/urls-auth
+
+## Base URLs
+- Production: [https://finrl-actions-production.up.railway.app](https://finrl-actions-production.up.railway.app)
+- Local development: [http://localhost:8000](http://localhost:8000)
+
+## Endpoints
+- **POST /train** — Train using journal entries and optionally save parameters.
+- **GET /predict** — Retrieve the latest trained parameters.
+- **GET /healthz** — Basic liveness probe. Returns `{ "status": "ok" }`.
+- **GET /readyz** — Readiness probe that checks upstream dependencies and optionally returns details.
+
+## Authentication
+- All training and prediction endpoints require an API key via the `X-API-Key` header. Health probes do not require authentication.
+- The upstream FinRL service base URL is configured via the environment variable `FINRL_BASE_URL` and defaults to `http://finrl:8000`.
+- The FinRL signal provider uses `FINRL_PREDICT_URL` (default `http://finrl:8000/predict`) to fetch parameters from the upstream service.
+
+Sources:
+- OpenAPI server definitions for production and local environments
+- Endpoint descriptions and security requirements
+- Environment variable notes from settings file

--- a/docs/finrl/02-finrl-env-vars.md
+++ b/docs/finrl/02-finrl-env-vars.md
@@ -1,0 +1,26 @@
+# 02-finrl-env-vars.md
+version: 2025-09-08
+status: canonical
+scope: finrl/env-vars
+
+## Purpose
+Document the configuration knobs that must be set via environment variables when deploying the FinRL‑actions service.  Correct configuration ensures that the service can authenticate inbound requests, forward training and prediction calls to the upstream FinRL engine and journaling service, and segregate environments.
+
+## Required variables
+| Variable | Default | Description |
+|---------|---------|-------------|
+| **API_KEY** | — | API key required in the `X‑API‑Key` header for all endpoints except health probes.  Requests lacking this key are rejected. |
+| **FINRL_BASE_URL** | `http://finrl:8000` | Base URL of the upstream FinRL service used for proxy routes.  Training and prediction requests are forwarded here. |
+| **FINRL_API_KEY** | (unset) | Optional API key added to the `X‑API‑Key` header on outbound calls to the upstream FinRL service. |
+| **ENV** | `default` | Label used to segregate watchlists or context.  Currently unused but reserved for future expansion. |
+| **JOURNAL_STORAGE_BASE_URL** | `http://journal:8000` | Base URL of the external journaling service used to persist parameter blobs. |
+| **JOURNAL_API_KEY** | — | API key for the journaling service.  Sent in the `X‑API‑Key` header when saving or retrieving parameters. |
+| **FINRL_PREDICT_URL** | `http://finrl:8000/predict` | URL used by the FinRL signal provider to fetch the latest parameters from the upstream service.  Overrides `FINRL_BASE_URL` for synchronous calls. |
+
+## Notes
+- `DATABASE_URL` was removed — the service no longer uses a local Postgres database for parameter storage.  All persistence is delegated to the external journal service.
+- Leave optional keys unset if the upstream FinRL service does not require authentication.
+
+Sources:
+- Environment variable definitions and defaults
+- Removal of Postgres storage and external journaling service notes

--- a/docs/finrl/03-finrl-train.md
+++ b/docs/finrl/03-finrl-train.md
@@ -1,0 +1,62 @@
+# 03-finrl-train.md
+version: 2025-09-08
+status: canonical
+scope: finrl/train
+
+## Endpoint
+- **POST /train**
+
+## Description
+Accepts a list of trade journal entries and derives basic strategy parameters.  It computes the win rate and average R‑multiple across the journal, assigns conservative default multipliers, and optionally persists the derived parameter blob to an external journaling service.
+
+## Request body
+A JSON object containing:
+
+- **journal_data** (array, required) – A list of trade entries.  Each entry may include:
+  * `symbol` (string, required)
+  * `side` (string, optional; e.g. "buy" or "sell")
+  * `strategy` (string, optional) – strategy tag such as “Pullback” or “ORB”
+  * `entry_time`, `exit_time` (ISO 8601 timestamps, optional)
+  * `entry_price`, `exit_price` (floats, optional)
+  * `stop_price`, `tp_price` (floats, optional)
+  * `outcome` (string, optional; e.g. "win", "loss", "tp", "sl", "manual")
+  * `R_multiple` (float, optional) – realized return in R units
+  * `notes` (string, optional)
+- **save_params** (boolean, default `true`) – If `true`, the derived parameters are saved to the external journal service.  Otherwise they are returned without persistence.
+- **version** (string, optional) – Custom version identifier.  If omitted, a version string beginning with `journal:` and containing the current UTC timestamp is generated.
+
+Unknown fields are rejected (`extra="forbid"`).  An empty `journal_data` list yields a `400` error.
+
+## Derivation logic
+For a journal of *n* entries, the service computes:
+
+- **win_rate** – fraction of entries considered wins.  A win is determined by the `outcome` starting with "win" or a positive `R_multiple`.
+- **avg_R** – arithmetic mean of all provided `R_multiple` values or a proxy based on the outcome field.
+- **default_stop_R** – fixed at `1.0` as a conservative stop multiplier.
+- **target_R** – fixed at `2.0` as a baseline take‑profit multiplier.
+- **notes** – a constant string "Derived from journal_data" identifying how the parameters were obtained.
+
+The version label defaults to `journal:<timestamp>` if none is provided.
+
+## Persistence
+If `save_params` is `true`, the service posts the derived parameters to `{JOURNAL_STORAGE_BASE_URL}/params` with JSON `{ "version", "source":"finrl", "blob": params }` and the `X‑API‑Key` header set to `JOURNAL_API_KEY`.  Any error in saving results in a `502` response.
+
+## Response
+On success, returns a JSON object:
+
+- **version** – Version identifier used when saving the parameter blob.
+- **params** – Object containing keys `win_rate`, `avg_R`, `default_stop_R`, `target_R`, `notes`.
+- **saved** (boolean) – `true` if the blob was persisted to the journal service, `false` otherwise.
+
+## Example
+```bash
+curl -X POST https://finrl-actions-production.up.railway.app/train \
+  -H "X-API-Key: <your_key>" \
+  -H "Content-Type: application/json" \
+  -d '{"journal_data":[{"symbol":"AAPL","side":"buy","entry_price":163.04,"outcome":"win","R_multiple":2.0}], "save_params":true }'
+```
+
+Sources:
+- Train endpoint definition and body schema
+- Parameter derivation logic
+- Persistence mechanism and response structure

--- a/docs/finrl/04-finrl-predict.md
+++ b/docs/finrl/04-finrl-predict.md
@@ -1,0 +1,40 @@
+# 04-finrl-predict.md
+version: 2025-09-08
+status: canonical
+scope: finrl/predict
+
+## Endpoint
+- **GET /predict**
+
+## Description
+Fetch the most recently saved parameter blob from the journaling service.  Optionally specify a version identifier to retrieve a particular snapshot.  This endpoint allows clients to query tuned strategy parameters without re‑running training.
+
+## Query parameters
+- **version** (string, optional) – Specific version label to retrieve.  If omitted or set to `latest`, the most recent parameters are returned.
+
+## Processing
+The service makes a GET request to the journaling service:
+- If a version is provided and not equal to `"latest"`, it queries `{JOURNAL_STORAGE_BASE_URL}/params/{version}` with `source=finrl` in the query string.
+- Otherwise, it queries `{JOURNAL_STORAGE_BASE_URL}/params/latest` with `source=finrl`.
+- The `X‑API‑Key` header is set to `JOURNAL_API_KEY`.
+If the journal service returns a 404 response, the FinRL‑actions service responds with `{ "detail": "No signals available (train first or save parameters)" }`.  Other error conditions are surfaced as a `502` response.
+
+## Response
+A JSON object containing:
+- **version** – The version identifier of the returned parameters.
+- **params** – The saved parameter blob.  Keys such as `win_rate`, `avg_R`, `default_stop_R`, `target_R`, etc., depend on the training logic.
+
+## Example
+```bash
+# Retrieve the latest parameters
+curl -X GET -H "X-API-Key: <your_key>" \
+  https://finrl-actions-production.up.railway.app/predict
+
+# Retrieve a specific version
+curl -X GET -H "X-API-Key: <your_key>" \
+  https://finrl-actions-production.up.railway.app/predict?version=journal:2025-08-28T10:00:00Z
+```
+
+Sources:
+- Predict endpoint logic and error handling
+- Journal storage retrieval logic

--- a/docs/finrl/05-finrl-health.md
+++ b/docs/finrl/05-finrl-health.md
@@ -1,0 +1,24 @@
+# 05-finrl-health.md
+version: 2025-09-08
+status: canonical
+scope: finrl/health
+
+## Health endpoints
+The FinRL‑actions service exposes health probes for monitoring and orchestration.
+
+### GET /healthz
+Returns a simple liveness indicator.  When the service is running, it responds with:
+```json
+{ "status": "ok" }
+```
+Authentication is not required.  Use this endpoint to verify that the service process is responding.
+
+### GET /readyz
+Readiness probe that checks upstream dependencies, such as the journaling service or the upstream FinRL engine.  An optional query parameter `detail` (boolean) can be supplied to include additional environment details in the response.  Possible responses:
+- **200 OK** – The service and its dependencies are ready.
+- **503 Service Unavailable** – One or more dependencies are unreachable.
+Authentication is not required by default.  This endpoint is defined in the OpenAPI specification but may not yet be implemented in the current code base.
+
+Sources:
+- Liveness probe implementation
+- OpenAPI readiness probe definition

--- a/docs/finrl/06-finrl-journal.md
+++ b/docs/finrl/06-finrl-journal.md
@@ -1,0 +1,47 @@
+# 06-finrl-journal.md
+version: 2025-09-08
+status: canonical
+scope: finrl/journal
+
+## Purpose
+Describe how the FinRL‑actions service persists and retrieves learned parameters via an external journaling service.  The journaling layer replaces the local Postgres storage used in earlier versions of the service.
+
+## Saving parameters
+When training completes and `save_params` is `true`, the service posts the derived parameter blob to the journaling service.  The target URL is constructed as:
+``
+{JOURNAL_STORAGE_BASE_URL}/params
+``
+The POST body includes:
+- `version` – version identifier of the parameter set
+- `source` – fixed string "finrl" to distinguish FinRL‑actions blobs
+- `blob` – the parameter dictionary
+The call uses an `X-API-Key` header containing `JOURNAL_API_KEY`.  Any failure to save raises a `502` error.
+
+## Retrieving parameters
+To fetch parameters, the service sends a GET request to either:
+- `{JOURNAL_STORAGE_BASE_URL}/params/latest?source=finrl` to obtain the most recent parameters; or
+- `{JOURNAL_STORAGE_BASE_URL}/params/{version}?source=finrl` to fetch a specific version.
+The same `X-API-Key` header is included.  If the journaling service returns a 404, the FinRL‑actions service forwards a message indicating that no signals are available.
+
+## Normalization
+The journaling API may return keys such as `blob`, `params` or `data`.  The FinRL‑actions service normalizes the response to return a consistent object with `version` and `params` fields.
+
+## Example
+``
+# Save parameters (performed internally during /train)
+POST {JOURNAL_STORAGE_BASE_URL}/params
+Headers: X-API-Key: <JOURNAL_API_KEY>
+Body: {"version":"journal:2025-09-08T12:00:00Z","source":"finrl","blob":{"win_rate":0.5,"avg_R":0.8,...}}
+
+# Retrieve latest parameters
+GET {JOURNAL_STORAGE_BASE_URL}/params/latest?source=finrl
+Headers: X-API-Key: <JOURNAL_API_KEY>
+
+# Retrieve specific version
+GET {JOURNAL_STORAGE_BASE_URL}/params/journal:2025-09-08T12:00:00Z?source=finrl
+Headers: X-API-Key: <JOURNAL_API_KEY>
+```
+
+Sources:
+- Journal save logic in the training endpoint
+- Journal retrieval logic in the prediction endpoint

--- a/docs/finrl/07-finrl-eval.md
+++ b/docs/finrl/07-finrl-eval.md
@@ -1,0 +1,30 @@
+# 07-finrl-eval.md
+version: 2025-09-08
+status: canonical
+scope: finrl/evaluation
+
+## Purpose
+Provide a quick reference for evaluation utilities included with the FinRL‑actions repository.  These functions assist in assessing strategy performance and overfitting risk but are not directly exposed via API endpoints.
+
+## Metrics
+
+### Sharpe ratio
+`sharpe(returns: np.ndarray, rf: float = 0.0) -> float`
+
+Computes the annualized Sharpe ratio of a series of returns with respect to a risk‑free rate `rf`.  It subtracts the risk‑free rate from the returns, then divides the mean by the sample standard deviation and scales by √252 (trading days per year).  If the standard deviation is zero, the function returns 0.
+
+### Deflated Sharpe ratio
+`deflated_sharpe(sr: float, n_trials: int, skew: float = 0.0, kurt: float = 3.0) -> float`
+
+Estimates a confidence adjustment for a Sharpe ratio given multiple trials.  The approximation penalizes the Sharpe ratio by `√(log(n_trials))` and maps the result to a 0–1 confidence via `tanh`.  When `n_trials` ≤ 1, it returns a baseline confidence based solely on the ratio.
+
+### Probability of Backtest Overfitting (PBO)
+`pbo_from_ranks(in_sample_ranks, out_sample_ranks) -> float`
+
+Given arrays of in‑sample and out‑of‑sample ranks, computes the fraction of cases where the best in‑sample model performs worse than the median out‑of‑sample performance.  Higher values indicate a greater risk of overfitting.
+
+## Notes
+These functions live in the `ml/eval/metrics.py` module and are intended for offline analysis.  They are not part of the FinRL‑actions API but may inform strategy research.
+
+Sources:
+- Evaluation metric implementations


### PR DESCRIPTION
## Summary
- add canonical documentation for FinRL actions service
- document environment variables and endpoint behaviors
- describe training, prediction, health, journal persistence, and evaluation utilities

## Testing
- `pre-commit run --files docs/finrl/01-finrl-urls-auth.md docs/finrl/02-finrl-env-vars.md docs/finrl/03-finrl-train.md docs/finrl/04-finrl-predict.md docs/finrl/05-finrl-health.md docs/finrl/06-finrl-journal.md docs/finrl/07-finrl-eval.md`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bee49d1820832f97640c7dce18666d