### PR TITLE
docs: add journals service documentation

### DIFF
--- a/docs/journals/01-journals-urls-auth.md
+++ b/docs/journals/01-journals-urls-auth.md
@@ -1,0 +1,27 @@
+# 01-journals-urls-auth.md
+version: 2025-09-08
+status: canonical
+scope: journals/urls-auth
+
+## Base URLs
+- Production: [https://turbo-broccoli-production.up.railway.app](https://turbo-broccoli-production.up.railway.app)
+- Local development: [http://localhost:8000](http://localhost:8000)
+
+## Endpoints summary
+- **POST /journal** — Create a journal entry.
+- **POST /journal/bulk** — Bulk insert multiple entries (payload has an `items` array).
+- **GET /journal** — List entries; filter by symbol, strategy, start/end timestamps; limit results.
+- **GET /journal/{id}** — Retrieve a single entry.
+- **PATCH /journal/{id}** — Update fields on an entry.
+- **DELETE /journal/{id}** — Remove an entry.
+- **GET /stats** — Compute trades, win rate and average R per symbol/strategy.
+- **POST /params** — Save a versioned parameter blob.
+- **GET /params/latest** — Get the most recent parameter blob, optional source/version filters.
+- **GET /health** — Liveness check with DB URL.
+- **GET /readyz** — Readiness check; optional `detail` flag for DB info.
+- **GET /openapi.yaml** — Download the OpenAPI spec.
+
+## Authentication
+- All endpoints except `/health`, `/readyz` and `/openapi.yaml` require an API key in the `X‑API‑Key` header.
+- The expected key comes from the `JOURNAL_API_KEY` environment variable; invalid or missing keys return HTTP 401.
+

--- a/docs/journals/02-journals-env-vars.md
+++ b/docs/journals/02-journals-env-vars.md
@@ -1,0 +1,20 @@
+# 02-journals-env-vars.md
+version: 2025-09-08
+status: canonical
+scope: journals/env-vars
+
+## Required variables
+
+| Variable            | Default                              | Description |
+|--------------------|--------------------------------------|-------------|
+| **JOURNAL_API_KEY** | —                                    | API key required in the `X‑API‑Key` header for all protected endpoints. |
+| **DB_ENGINE**       | `sqlite`                             | Database engine (`sqlite` or `duckdb`). |
+| **DB_DIR**          | `$DB_DIR` or `$RAILWAY_VOLUME_MOUNT_PATH` or `/app/data` | Directory where the database file lives. |
+| **DB_FILE**         | `journals.db` (sqlite) or `journals.duckdb` (duckdb) | Name of the DB file. |
+| **PUBLIC_URL**      | `https://turbo-broccoli-production.up.railway.app` | Absolute server URL used in OpenAPI spec. |
+
+## Notes
+- The API key is validated against `JOURNAL_API_KEY` for every protected route.
+- `DB_ENGINE`, `DB_DIR` and `DB_FILE` construct the `DATABASE_URL` at runtime.
+- Setting `PUBLIC_URL` ensures that the OpenAPI spec shows the correct base path.
+

--- a/docs/journals/03-journals-journal-entries.md
+++ b/docs/journals/03-journals-journal-entries.md
@@ -1,0 +1,27 @@
+# 03-journals-journal-entries.md
+version: 2025-09-08
+status: canonical
+scope: journals/journal-entries
+
+## Models
+
+### JournalIn (request)
+Fields:
+`symbol` (string, max 32, required); `strategy` (string, max 64); `side` ("long" or "short"); `entry_time`, `exit_time` (datetime); `entry_price`, `exit_price`, `stop_price`, `tp_price` (floats); `r_multiple` (float); `outcome` (string); `notes` (string); `tags` (JSON object).
+Unknown fields are ignored.
+
+### JournalOut (response)
+Extends `JournalIn` with `id` (int), `created_at` and `updated_at` timestamps.
+
+## Endpoints
+
+- **POST /journal** – Accepts a `JournalIn`, returns the created entry with ID and timestamps.
+- **POST /journal/bulk** – Accepts `{ "items": [JournalIn, …] }`, inserts all entries and returns a list of `JournalOut`.
+- **GET /journal** – Query parameters: `symbol`, `strategy`, `start`, `end`, `limit` (default 200). Returns a list of entries ordered by creation time.
+- **GET /journal/{id}** – Retrieves a single entry by ID; returns 404 if not found.
+- **PATCH /journal/{id}** – Updates provided fields; missing fields are left unchanged.
+- **DELETE /journal/{id}** – Deletes the entry; returns 204 on success.
+
+### GET /stats
+Aggregates journal data. Query parameters: `symbol`, `strategy`, `start`, `end`. Returns objects with `symbol`, `strategy`, `trades` (count), `win_rate` (mean of positive R) and `avg_r` (average R).
+

--- a/docs/journals/04-journals-params.md
+++ b/docs/journals/04-journals-params.md
@@ -1,0 +1,23 @@
+# 04-journals-params.md
+version: 2025-09-08
+status: canonical
+scope: journals/params
+
+## Models
+
+### ParamIn (request)
+- **version** (string, required) – Human‑readable identifier.
+- **source** (string, optional, default "finrl") – Origin of the parameters.
+- **blob** (object, required) – Arbitrary JSON payload.
+
+### ParamOut (response)
+Extends `ParamIn` with `id` (int) and `created_at` (datetime).
+
+## Endpoints
+
+- **POST /params** – Saves a new parameter record and returns it with ID and creation time.
+- **GET /params/latest** – Returns the most recent `ParamOut`. Optional query parameters: `source` and `version`. Returns 404 if no match or 500 if a DB error occurs.
+
+### GET /openapi.yaml
+Serves the OpenAPI 3.1 specification in YAML format. This endpoint is excluded from the API schema but can be fetched directly.
+

--- a/docs/journals/05-journals-health.md
+++ b/docs/journals/05-journals-health.md
@@ -1,0 +1,11 @@
+# 05-journals-health.md
+version: 2025-09-08
+status: canonical
+scope: journals/health
+
+## Health endpoints
+
+- **GET /health** – Returns `{ "ok": true, "db": "<DATABASE_URL>" }` indicating the service is running and the database connection string. No API key required.
+- **GET /readyz** – Checks database connectivity. Without parameters returns `{ "ready": true }` on success. With `detail=true` it also returns the `db` field. Returns HTTP 503 with an error message if the DB is unreachable.
+- **GET /openapi.yaml** – Provides the current OpenAPI specification as YAML. Useful for client generation and documentation.
+


### PR DESCRIPTION
## Summary
- document journals API endpoints and authentication
- outline environment variables for journals service
- add models and endpoints for journal entries and params
- describe health and readiness endpoints

## Testing
- `make lint`
- `make test` *(fails: ModuleNotFoundError: No module named 'requests_mock')*


------
https://chatgpt.com/codex/tasks/task_e_68beec900adc832fb7d633664c11bc43