### PR TITLE
Add alpha classifier documentation

### DIFF
--- a/docs/alpha/01-alpha-urls-auth.md
+++ b/docs/alpha/01-alpha-urls-auth.md
@@ -1,0 +1,24 @@
+# 01-alpha-urls-auth.md
+version: 2025-09-08
+status: canonical
+scope: alpha/urls-auth
+
+## Base URLs
+- Production: https://alpha-classifier-production.up.railway.app
+- Local development: http://localhost:8000
+
+## Endpoints summary
+- **POST /classify** — Classify a batch of tickers and return metrics and candidate tags.
+- **GET /healthz** — Liveness check.
+
+## Authentication
+- All POST `/classify` requests require `X-API-Key` header matching the environment variable `ALPHA_CLASSIFIER_KEY`.
+- If the key is missing or incorrect, the service returns HTTP 401.
+
+### Example
+```bash
+curl -X POST https://alpha-classifier-production.up.railway.app/classify \
+  -H "X-API-Key: <your_key>" \
+  -H "Content-Type: application/json" \
+  -d '{"symbols": ["AAPL","NVDA","TSLA"]}'
+```

--- a/docs/alpha/02-alpha-env-vars.md
+++ b/docs/alpha/02-alpha-env-vars.md
@@ -1,0 +1,16 @@
+# 02-alpha-env-vars.md
+version: 2025-09-08
+status: canonical
+scope: alpha/env-vars
+
+## Required variables
+
+| Variable               | Description |
+|-----------------------|-------------|
+| **FINNHUB_TOKEN**      | Token for the Finnhub API. The service will not start without it. |
+| **ALPHA_CLASSIFIER_KEY** | API key required in the `X-API-Key` header on classify requests. |
+
+## Notes
+
+- The classifier makes network calls to `https://finnhub.io/api/v1/stock/candle` using `FINNHUB_TOKEN`.
+- Both variables must be set; otherwise the application raises an error at startup.

--- a/docs/alpha/03-alpha-classify.md
+++ b/docs/alpha/03-alpha-classify.md
@@ -1,0 +1,39 @@
+# 03-alpha-classify.md
+version: 2025-09-08
+status: canonical
+scope: alpha/classify
+
+## Endpoint: POST /classify
+
+Classifies a list of symbols and returns technical metrics and candidate tags.
+
+### Request
+- **Header:** `X-API-Key` must match `ALPHA_CLASSIFIER_KEY`.
+- **Body:** JSON object with properties:
+  - `symbols` (list[string], required) — List of tickers to classify.
+  - `rvolMode` (string, optional) — Reserved for future volume modes; defaults to `"20bar"`.
+    - If no symbols are provided, the service returns HTTP 422.
+    - If more than 50 symbols are provided, the service returns HTTP 413.
+
+### Processing
+- Symbols are deduplicated and upper-cased.
+- The service fetches up to 200 daily candles and 10 days of 15-minute candles per symbol from Finnhub.
+- It computes technical indicators and applies classification rules (see metrics doc).
+
+### Response
+Returns a JSON array of objects, each with fields:
+- `symbol` – Ticker symbol.
+- `close` – Last closing price.
+- `sma50` – 50-day simple moving average.
+- `atr` – 14-day average true range.
+- `pir_pct` – Percent position in last 5-day range.
+- `rvol15` – 15-minute relative volume (latest bar vs prior 20 bars).
+- `candidates` – Comma-separated tags (see metrics doc).
+- `confirm` – `"confirm_15m"` if `rvol15` ≥ 1.2, otherwise `"pending"`.
+
+If an error occurs for a symbol (e.g., no data), the output includes default values and an `error:<message>` tag.
+
+### Limits & Concurrency
+- Maximum 50 symbols per request; excess returns HTTP 413.
+- Classification uses a thread pool with up to 8 workers (min of 8 and number of symbols).
+- The service retries Finnhub calls up to 4 times with exponential backoff on 429 responses.

--- a/docs/alpha/04-alpha-metrics.md
+++ b/docs/alpha/04-alpha-metrics.md
@@ -1,0 +1,25 @@
+# 04-alpha-metrics.md
+version: 2025-09-08
+status: canonical
+scope: alpha/metrics
+
+## Technical indicators
+
+The classifier computes several metrics from historical price and volume data:
+
+- **SMA50** – 50-day simple moving average of closing prices.
+- **ATR14** – 14-period average true range computed from daily highs, lows and closes.
+- **PIR (position-in-range)** – Position of last daily close in the range of the last 5 days, expressed as a percentage.
+- **RVOL15** – Relative volume of the most recent 15-minute bar compared to the average of the previous 20 bars.
+- **Bar position** – Position of the current daily close within today’s high-low range.
+
+## Classification rules
+
+Based on these indicators, the classifier assigns one or more tags:
+
+- **Pullback Long** – Close above SMA50, PIR ≤ 25%, bar position ≥ 75%.
+- **Breakout Long** – Close equals or exceeds the highest high of the last 20 days.
+- **Breakdown Short** – No previous tags, close is below both SMA50 and the minimum low of the last 20 days.
+- **Range** – PIR ≤ 15% or ≥ 85%.
+
+The output field `confirm` indicates whether the 15-minute relative volume is strong (`"confirm_15m"`) or requires further confirmation (`"pending"`).

--- a/docs/alpha/05-alpha-health.md
+++ b/docs/alpha/05-alpha-health.md
@@ -1,0 +1,14 @@
+# 05-alpha-health.md
+version: 2025-09-08
+status: canonical
+scope: alpha/health
+
+## Endpoint: GET /healthz
+
+Returns a simple liveness indicator:
+
+```json
+{ "ok": true }
+```
+
+This endpoint does not require authentication and can be used for monitoring.


### PR DESCRIPTION
## Summary
- document alpha classifier service URLs, auth, and endpoints
- add env var requirements for classifier
- describe classify workflow, metrics, and health check

## Testing
- `pre-commit run --files docs/alpha/01-alpha-urls-auth.md docs/alpha/02-alpha-env-vars.md docs/alpha/03-alpha-classify.md docs/alpha/04-alpha-metrics.md docs/alpha/05-alpha-health.md`


------
https://chatgpt.com/codex/tasks/task_e_68beefa717bc832fbe269a8a14c72805