### PR TITLE
docs: add Finnhub API references

### DIFF
--- a/docs/finnhub/01-finnhub-urls-auth.md
+++ b/docs/finnhub/01-finnhub-urls-auth.md
@@ -1,0 +1,22 @@
+# 01-finnhub-urls-auth.md
+version: 2025-09-08
+status: canonical
+scope: finnhub/urls-auth
+
+## Base URL
+- [https://finnhub.io/api/v1](https://finnhub.io/api/v1)
+
+## Authentication
+- Supply your API key via the `X-Finnhub-Token` header or the `token` query parameter on every request.
+- The service enforces a per‑account call cap of ~30 requests per second; requests above this threshold return HTTP 429 status.
+
+## Plan categories
+- **marketdata‑basic** – Provides real‑time quotes, historical candles, company news, symbol search, option chains and technical indicators (some indicators require premium).
+- **fundamentals‑1** – Enables company profile, basic financial metrics, earnings history, earnings calendar, analyst recommendations, peers, insider transactions and some ownership data.
+- **premium** – Unlocks news sentiment, social sentiment, advanced ownership reports and most technical indicators. Endpoints marked as premium will return `403 Access Denied` on lower plans.
+
+## Notes
+- All endpoints are read‑only (`GET`) and return JSON.
+- Date ranges must be supplied in `YYYY‑MM‑DD` format; timestamps are Unix seconds.
+- Always respect plan limits and handle `429` responses gracefully.
+

--- a/docs/finnhub/02-finnhub-quotes.md
+++ b/docs/finnhub/02-finnhub-quotes.md
@@ -1,0 +1,39 @@
+# 02-finnhub-quotes.md
+version: 2025-09-08
+status: canonical
+scope: finnhub/quotes
+
+## Real‑time quote
+- **Endpoint**: `GET /quote`
+- **Params**: `symbol` (required) – Ticker symbol.
+- **Description**: Returns a snapshot of the most recent trade for a stock, including current price and daily range.
+- **Response fields**:
+
+  * `c` – Current price.
+  * `d` – Change from previous close.
+  * `dp` – Percent change from previous close.
+  * `h` – High price of the day.
+  * `l` – Low price of the day.
+  * `o` – Open price of the day.
+  * `pc` – Previous close price.
+  * `t` – Unix timestamp (seconds).
+
+## Historical candles
+- **Endpoint**: `GET /stock/candle`
+- **Params**:
+
+  * `symbol` (required): Stock ticker.
+  * `resolution` (required): Interval. Supported values: `1`, `5`, `15`, `30`, `60`, `D`, `W`, `M`.
+  * `from` (required): Start time (Unix seconds).
+  * `to` (required): End time (Unix seconds).
+- **Description**: Fetches arrays of open‑high‑low‑close‑volume data at the specified resolution for the given period.
+- **Response fields**:
+
+  * `c` – Array of close prices.
+  * `h` – Array of high prices.
+  * `l` – Array of low prices.
+  * `o` – Array of open prices.
+  * `t` – Array of timestamps (seconds).
+  * `v` – Array of volumes.
+  * `s` – Status string (`"ok"` or `"no_data"`).
+

--- a/docs/finnhub/03-finnhub-fundamentals.md
+++ b/docs/finnhub/03-finnhub-fundamentals.md
@@ -1,0 +1,48 @@
+# 03-finnhub-fundamentals.md
+version: 2025-09-08
+status: canonical
+scope: finnhub/fundamentals
+
+## Company profile
+- **Endpoint**: `GET /stock/profile2`
+- **Params**: At least one of `symbol`, `isin` or `cusip`.
+- **Description**: Returns a company’s high‑level details such as name, exchange, IPO date, market capitalization, shares outstanding, country, currency, phone, website URL, logo and industry.
+
+## Basic financial metrics
+- **Endpoint**: `GET /stock/metric`
+- **Params**:
+
+  * `symbol` (required): Ticker.
+  * `metric` (required): Metric category (`all`, `price`, `valuation`, `margin`). Use `all` to return the full set.
+- **Description**: Returns a `metric` object containing selected ratios and statistics—such as P/E, 52‑week high/low and average trading volume—for the specified company.
+
+## Earnings surprises
+- **Endpoint**: `GET /stock/earnings`
+- **Params**:
+
+  * `symbol` (required): Company ticker.
+  * `limit` (optional): Number of records to return.
+- **Description**: Provides historical quarterly earnings results along with analysts’ estimates. Each record includes actual and estimated EPS, period, quarter, surprise and surprise percent.
+
+## Earnings calendar
+- **Endpoint**: `GET /calendar/earnings`
+- **Params**:
+
+  * `from` (required): Start date in `YYYY‑MM‑DD`.
+  * `to` (required): End date in `YYYY‑MM‑DD`.
+  * `symbol` (optional): Filter to a single ticker.
+- **Description**: Returns upcoming earnings dates within the specified range. Response fields include `date`, `symbol`, `hour`, `quarter`, `year`, `epsActual`, `epsEstimate`, `revenueActual` and `revenueEstimate`.
+
+## Recommendation trends
+- **Endpoint**: `GET /stock/recommendation` (alias: `/stock/recommendation-trends`)
+- **Params**: `symbol` (required).
+- **Description**: Returns monthly counts of analyst ratings for the last several months. Each record contains `period` (YYYY‑MM) and counts of `strongBuy`, `buy`, `hold`, `sell` and `strongSell` recommendations.
+
+## Peers
+- **Endpoint**: `GET /stock/peers`
+- **Params**:
+
+  * `symbol` (required): Ticker.
+  * `grouping` (optional): Grouping level (default `subIndustry`).
+- **Description**: Returns an array of peer tickers operating in the same sector or industry.
+

--- a/docs/finnhub/04-finnhub-news.md
+++ b/docs/finnhub/04-finnhub-news.md
@@ -1,0 +1,30 @@
+# 04-finnhub-news.md
+version: 2025-09-08
+status: canonical
+scope: finnhub/news
+
+## Company news
+- **Endpoint**: `GET /company-news`
+- **Params**:
+
+  * `symbol` (required): Company ticker.
+  * `from` (required): Start date `YYYY‑MM‑DD`.
+  * `to` (required): End date `YYYY‑MM‑DD`.
+- **Description**: Fetches the latest articles about a company. Each article includes `category`, `datetime` (Unix seconds), `headline`, `id`, `image`, `related` tickers, `source`, `summary` and `url`.
+
+## News sentiment (premium)
+- **Endpoint**: `GET /news-sentiment`
+- **Params**: `symbol` (required).
+- **Description**: Returns AI‑scored sentiment for recent news. The response includes:
+
+  * `buzz` – Article counts and news ratio.
+  * `companyNewsScore` – Composite sentiment score for the company.
+  * `sectorAverageBullishPercent` and `sectorAverageNewsScore` – Sector benchmarks.
+  * `sentiment` – Bearish and bullish percentages.
+- **Plan**: This endpoint is premium. Users on marketdata‑basic or fundamentals‑1 plans will receive `403 Access Denied`.
+
+## Social sentiment (premium)
+- **Endpoint**: `GET /stock/social-sentiment`
+- **Params**: `symbol` (required), `from` and `to` (optional).
+- **Description**: Provides daily counts of Reddit and Twitter mentions, positive and negative scores and an overall sentiment score. Response fields include `mention`, `positiveMention`/`positiveScore`, `negativeMention`/`negativeScore`, `score`, `date`. This endpoint is premium and returns `403` on basic plans.
+

--- a/docs/finnhub/05-finnhub-search.md
+++ b/docs/finnhub/05-finnhub-search.md
@@ -1,0 +1,23 @@
+# 05-finnhub-search.md
+version: 2025-09-08
+status: canonical
+scope: finnhub/search
+
+## Symbol search
+- **Endpoint**: `GET /search`
+- **Params**:
+
+  * `q` (required): Query string (company name, ticker, ISIN or CUSIP).
+  * `exchange` (optional): Exchange code to restrict the results.
+- **Description**: Performs a fuzzy search for securities. The response includes a `count` and a `result` array; each entry contains `symbol`, `displaySymbol`, `description` and `type`.
+
+## Stock symbols
+- **Endpoint**: `GET /stock/symbol`
+- **Params**:
+
+  * `exchange` (required): Exchange code (e.g. `US`).
+  * `mic` (optional): Market identification code.
+  * `securityType` (optional): Filter by security type.
+  * `currency` (optional): Filter by currency.
+- **Description**: Returns a catalogue of all instruments available on the specified exchange. Each item provides `symbol`, `displaySymbol`, `description`, `currency`, `figi`, `mic` and other metadata.
+

--- a/docs/finnhub/06-finnhub-options-technicals.md
+++ b/docs/finnhub/06-finnhub-options-technicals.md
@@ -1,0 +1,26 @@
+# 06-finnhub-options-technicals.md
+version: 2025-09-08
+status: canonical
+scope: finnhub/options-technicals
+
+## Option chain
+- **Endpoint**: `GET /stock/option-chain`
+- **Params**:
+
+  * `symbol` (required): Stock ticker.
+  * `date` (optional): Expiration date `YYYY‑MM‑DD` to limit the chain.
+- **Description**: Returns a snapshot of available option contracts for a symbol. The response contains a list of expiration dates with an `options` object for each; `options` contains `CALL` and `PUT` arrays. Each contract summary includes `symbol`, `type` (`CALL` or `PUT`), `strike`, `lastPrice` and may include additional fields. According to the action schema, this endpoint is part of the marketdata‑basic plan, although official Finnhub docs classify detailed option data as premium.
+
+## Technical indicator series
+- **Endpoint**: `GET /indicator`
+- **Params**:
+
+  * `symbol` (required): Ticker.
+  * `resolution` (required): Interval (`1`, `5`, `15`, `30`, `60`, `D`, `W`, `M`).
+  * `from` (required): Start time (Unix seconds).
+  * `to` (required): End time (Unix seconds).
+  * `indicator` (required): Indicator name (e.g. `sma`, `ema`, `rsi`, `macd`).
+  * `timeperiod` (optional): Period parameter for certain indicators.
+- **Description**: Computes a technical indicator over the specified period and returns a `series` of numbers alongside a matching array of `timestamps`. For example, a 3‑period simple moving average returns the moving average for each closing price.
+- **Plan**: Finnhub labels this endpoint as premium; basic plans may receive `403` responses.
+

--- a/docs/finnhub/07-finnhub-insiders-ownership.md
+++ b/docs/finnhub/07-finnhub-insiders-ownership.md
@@ -1,0 +1,31 @@
+# 07-finnhub-insiders-ownership.md
+version: 2025-09-08
+status: canonical
+scope: finnhub/insiders-ownership
+
+## Insider transactions
+- **Endpoint**: `GET /stock/insider-transactions`
+- **Params**:
+
+  * `symbol` (optional): Company ticker. If omitted, returns the latest filings across all companies.
+  * `from` (optional): Start date `YYYY‑MM‑DD`.
+  * `to` (optional): End date `YYYY‑MM‑DD`.
+- **Description**: Returns Form 3/4/5 and related filings summarizing insider trades. Each record in the `data` array contains the insider’s `name`, number of `share`s held after the transaction, `change` from the previous period, `filingDate`, `transactionDate`, `transactionCode` and `transactionPrice`.
+
+## Insider sentiment
+- **Endpoint**: `GET /stock/insider-sentiment`
+- **Params**:
+
+  * `symbol` (required): Ticker.
+  * `from` (required): Start date `YYYY‑MM‑DD`.
+  * `to` (required): End date `YYYY‑MM‑DD`.
+- **Description**: Provides monthly insider sentiment for a company. Each item in the `data` array includes `month`, `year`, `change` (net buying/selling), `mspr` (monthly share purchase ratio) and `symbol`.
+
+## Ownership (premium)
+- **Endpoint**: `GET /stock/ownership`
+- **Params**:
+
+  * `symbol` (required): Company ticker.
+  * `limit` (optional): Maximum number of holders to return.
+- **Description**: Lists shareholders and their holdings. Each record includes the investor’s `name`, number of `share`s, `change` (net buy/sell) and `filingDate`. Finnhub notes that full ownership data requires a premium plan; users on fundamentals‑1 may receive `403 Access Denied`.
+


### PR DESCRIPTION
## Summary
- add canonical Finnhub docs outlining base URLs, auth, and plan categories
- document Finnhub endpoints for quotes, fundamentals, news, search, options/technicals, and insider/ownership data

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68befc2c4ca4832fa90faf65ca3116ce