### PR TITLE
Add trading knowledge references

### DIFF
--- a/docs/alpha-knowledge/alpha-classifier-specs.md
+++ b/docs/alpha-knowledge/alpha-classifier-specs.md
@@ -1,0 +1,82 @@
+Alpha Classifier Specs 🤖
+
+This file details the Alpha Classifier tool, including what inputs it expects, what outputs it produces, and how to interpret those outputs. The Alpha Classifier is a machine-learning model integrated into the assistant’s workflow for evaluating trade setups or market conditions quantitatively.
+
+Purpose
+
+The Alpha Classifier’s job is to analyze a given trading scenario or data set and output an alpha score or category that indicates the potential for abnormal returns (“alpha”) in that scenario. In simpler terms, it’s trying to gauge how good a trade or idea might be. This helps the assistant back up its recommendations with an objective model’s perspective.
+
+It’s called a classifier because it may bucket the outcome (e.g., “Strong Buy, Weak Buy, Neutral, Weak Sell, Strong Sell”) or provide a numeric score along a range which corresponds to such categories.
+
+Input Specification
+
+The classifier can take in various forms of input depending on context:
+
+Technical Features: It might ingest recent price data, indicators, volumes, volatility metrics, etc. For instance, it could use values like RSI, moving average slopes, volume surge info, etc., pertaining to the asset in question. The assistant will assemble such data points from Finnhub or internal calculations when invoking the classifier.
+
+Fundamental or News Features: If the scenario involves news or fundamentals (like an earnings report sentiment, or a sector rotation), the classifier might also accept summarized sentiment or fundamental metrics. For example, it could take as input “earnings beat by 10%, stock gapped +5%” or a sentiment score of recent news headlines.
+
+Trade Context: If evaluating a specific trade setup, context such as entry price, stop, target might be input so the classifier knows the risk-reward. Or if comparing multiple stocks, their relative strengths can be input to pick best.
+
+In practice for the assistant, a lot of this is abstracted – the assistant just calls the classifier with whatever features it has on hand about the situation. For user transparency, we can say it considers technical and possibly fundamental factors of the asset.
+
+Example Input Case: User asks “How strong is the setup for XYZ?” The assistant gathers that XYZ has RSI 72, just broke out of a range, RVOL 2.5, moderate earnings growth, etc. These are fed to the classifier.
+
+Note: The user doesn’t directly see this input; it’s internal. But we ensure to explain output with relevant factors.
+
+Output Specification
+
+The Alpha Classifier returns either a numeric score or a category label (or both).
+
+Alpha Score: Typically a float between 0 and 1 (or 0 to 100 if percentile). Higher means more bullish (higher expected alpha), lower means more bearish (negative expected alpha). For instance: 0.9 might mean a strong buy signal, 0.5 neutral, 0.1 strong sell. Sometimes it could output negative values if convention set that negative = short favorability, but likely 0-1 scaled where <0.5 implies underperformance expectation.
+
+Classification Label: It may map the score into human-friendly classes. e.g., Score >0.8 = “Strong Long”, 0.6-0.8 “Moderate Long”, 0.4-0.6 “Neutral/Hold”, 0.2-0.4 “Moderate Short”, <0.2 “Strong Short”. This is an example mapping. The actual model may have, say, 5 classes or a continuous score.
+
+We will assume a 5-tier interpretation: Strong Buy, Buy, Hold, Sell, Strong Sell corresponding to very bullish to very bearish outlooks. Or similarly worded categories.
+
+Additional outputs: The classifier might also provide some sub-scores or rationale features (if it’s an explainable model). For instance, it might highlight which factors influenced it (like “momentum +0.3, fundamentals +0.1, volatility -0.05, overall score 0.35” – just hypothetical). If such detail is available, the assistant can use it to explain why the score is what it is. If not, the assistant infers based on known inputs (like “Classifier likely liked the strong momentum and volume”).
+
+Score Meaning and Guidance
+
+We interpret the classifier’s output for the user in plain language, also citing the numeric for precision if needed:
+
+Strong Buy (Score ~0.8-1.0): The model sees very high positive alpha potential. This suggests the trade or asset has a high probability of outperforming / a very favorable setup. In practice, the assistant will say something like “The AI classifier rates this as a Strong Buy (score 0.85) – indicating a high-confidence bullish signal.”
+
+Buy (Score ~0.6-0.8): Moderately positive. A good setup, albeit not top-tier, but still expected to yield above-average returns. The assistant might say “moderately bullish”. If user is looking for longs, it’s a yes, if being picky maybe only go for strong buys.
+
+Hold/Neutral (Score ~0.4-0.6): The model expects average or uncertain outcome – no clear edge. Could mean mixed signals. “The classifier is neutral on this – score 0.5, suggesting limited edge (it might perform in line with general market or it’s too uncertain).”
+
+Sell (Score ~0.2-0.4): Moderately negative. Suggests likely underperformance or a poor setup. If user was considering a long, that’s a caution sign; if considering short, maybe a mild opportunity. “Classifier sees bearish bias – perhaps best to avoid or consider short, score 0.3.”
+
+Strong Sell (Score ~0.0-0.2): The model is strongly negative on it. Possibly a failing company or very weak technicals. “It’s giving a strong sell signal (score 0.1), implying high confidence that this will underperform or drop.”
+
+Exact numeric cutoffs can be refined, but those ranges are conceptually how we map it. The assistant shouldn’t present the raw score as gospel but as one input. Also, mention if the difference is small. E.g., if something is score 0.55 vs another 0.50, not a big difference – both neutralish. But 0.85 vs 0.4 is clearly different.
+
+Confidence & Reliability: The assistant may note that the classifier is a tool, not guaranteed. E.g., “The classifier’s confidence is high, but it’s based on historical patterns – always wise to also consider current fundamentals/news.” If score is near 0.5, basically it’s saying no edge – which itself is information (maybe skip trade).
+
+Integration into Workflow
+
+The assistant will call the classifier typically when the user asks for an analysis like “Should I buy this?” or “How does this setup look?” or even on its own to cross-check its human analysis.
+
+If the classifier output conflicts with other analysis, the assistant might say “Our technical analysis looked good, but the AI model isn’t as convinced (score only 0.45). This discrepancy suggests caution.” Or vice versa. It helps add a second opinion.
+
+The classifier might also be used to rank a list of candidates. E.g., user says “Which of these 5 stocks is best?” The assistant can get scores for all and say “The classifier favors stock A (0.78) over others (next highest was 0.6), indicating A has the best projected alpha.”
+
+When not to use blindly: If a situation has factors the classifier might not have seen (e.g., an unprecedented news or it’s a penny stock with unusual conditions), the assistant should note the limitations. “The classifier output might not fully account for the current meme-stock frenzy, so take it with salt.”
+
+Example Interpretation to User
+
+User: “I’m thinking of going long ACME Corp. What’s the outlook?”
+Assistant: “Based on the current data, the Alpha Classifier gives ACME a score of 0.82, which falls in a ‘Strong Buy’ range. That indicates the setup is quite favorable
+investopedia.com
+. This high score likely reflects ACME’s strong upward momentum (it recently broke out to 52-week highs on high volume) and solid fundamentals (earnings growth last quarter). In other words, the AI model has high confidence in ACME’s upside potential. Of course, no model is 100% — but this is a positive sign.”
+
+Another:
+User: “How about Beta Inc? It’s been dropping; do we see a rebound?”
+Assistant: “The classifier score for Beta Inc. is only 0.25, a ‘Sell’ signal. It suggests continued weakness — likely because Beta’s technical trend is still down (it’s trading below key moving averages) and there’s no sign of reversal momentum yet. In model terms, that’s a pretty bearish outlook, so catching a falling knife here might be risky.”
+
+Finally:
+If user asks to explain classifier:
+Assistant can say it looks at dozens of indicators and patterns learned from historical data to output that score, in a user-friendly manner: “It’s basically summarizing a bunch of factors into one number for how good or bad this looks.”
+
+Remember, the assistant should never just say “classifier says buy so do it.” It should incorporate it as one piece of advice, albeit important. Always pair with context like why it might be saying that if possible (momentum, fundamentals, etc.). That makes the recommendation more transparent and trustworthy.

--- a/docs/alpha-knowledge/finnhub-api-quick-reference.md
+++ b/docs/alpha-knowledge/finnhub-api-quick-reference.md
@@ -1,0 +1,120 @@
+Finnhub API Endpoints Quick Reference 🔍
+
+This reference maps common data tasks to the relevant Finnhub API endpoints and required parameters. The assistant uses these endpoints to retrieve financial data when asked. All endpoints require the API token (handled internally), so the user only needs to specify the query, not the token.
+
+Below are typical use-cases and how to fulfill them with Finnhub:
+
+Get Current Stock Price (Quote):
+Endpoint: /quote?symbol={ticker}
+Description: Returns real-time quote data for a stock ticker. The JSON includes fields: c (current price), h (high of day), l (low of day), o (open price), pc (previous close), and t (timestamp).
+Usage: Use when user asks for the latest price or daily change of a stock.
+Example: For AAPL, GET .../quote?symbol=AAPL -> yields c:150.0, o:148.0, h:151.0, l:147.5, pc:149.0 etc. The assistant would parse and say: “AAPL is $150.00, up 0.7% from yesterday’s $149.00 close.” (Percent change can be derived: (c - pc)/pc *100%).
+
+Get Historical Prices (Candles):
+Endpoint: /stock/candle?symbol={ticker}&resolution={res}&from={unix_time_start}&to={unix_time_end}
+Description: Fetches historical OHLCV data (Open, High, Low, Close, Volume) for the given time resolution. resolution can be 1,5,15,30,60 (minutes), D (daily), W (weekly), M (monthly). The time range is specified in Unix timestamps (seconds since epoch).
+Usage: For charts, technical analysis, or backtesting data.
+Example: To get daily candles for 2023 YTD for GOOGL: set from=1672531200 (2023-01-01), to=1704067199 (2023-12-31). GET /stock/candle?symbol=GOOGL&resolution=D&from=1672531200&to=1704067199. The response lists arrays for t (time), o, h, l, c, v. The assistant can then calculate trends, or feed into indicators.
+
+Company News (Recent):
+Endpoint: /company-news?symbol={ticker}&from={YYYY-MM-DD}&to={YYYY-MM-DD}
+Description: Retrieves news articles related to the company in the given date range. Each article includes headline, summary, date, source, etc.
+Usage: Use when user asks "Any recent news on X?" or for catalyst analysis.
+Example: User: “What’s new with TSLA?” -> The assistant fetches last week’s news: from=2025-09-01&to=2025-09-08. It then might summarize: “Several news items: e.g., a new model launch rumor (source CNBC), and an analyst upgrade by Morgan Stanley
+stockstotrade.com
+.” The assistant should filter/summarize rather than listing raw JSON.
+
+General Market News:
+Endpoint: /news?category={category}
+Description: Provides latest market news in a category such as general, forex, crypto, merger.
+Usage: If user asks for market news or what's driving markets today.
+Example: “What’s the market news?” -> GET /news?category=general. Then pick a few top headlines: “Stocks rally as inflation cools; Fed hints at pause – Reuters.” and so on.
+
+Fundamental Data (Company Profile / Metrics):
+Profiles: /stock/profile2?symbol={ticker} returns basic info like company name, industry, CEO, etc. Useful if user asks “What does this company do?”
+Metrics: /stock/metric?symbol={ticker}&metric=all gives a host of fundamental metrics (PE ratio, EBITDA, margins, etc)
+interactivebrokers.com
+.
+Usage: For fundamental analysis questions like “What’s the P/E of GOOG?” or “How’s AAPL’s financial health?” The assistant can fetch metrics and quote some key ones
+columbia.edu
+: e.g., “AAPL P/E is 28, profit margin 22%
+interactivebrokers.com
+.”
+Possibly narrow metrics: Finnhub allows metric=all or specific metric groups like metric=price etc. Usually all covers most.
+
+Earnings Data:
+Latest Earnings (Surprises): /stock/earnings?symbol={ticker} gives recent earnings (actual vs estimate)
+stackoverflow.com
+. Use if asked “Did XYZ beat earnings?”
+Example: If user asks about last earnings of NFLX: GET /stock/earnings?symbol=NFLX might yield an array of recent quarters with actual, estimate. The assistant can say: “Last quarter, NFLX reported $3.20 EPS vs $3.00 expected – a beat
+dlthub.com
+.”
+Earnings Calendar: There’s also /calendar/earnings?from=...&to=... for upcoming earnings in a date range, or specifically earnings date for a ticker via profile2 or other endpoints. But for single ticker, profile2 includes ipo and sometimes next earnings date under nextEarningsDate if available. If user asks “When does XYZ report earnings?”, we might use alternative approach (Finnhub had an endpoint like /stock/earnings? with future flag? Or /calendar I can search via symbol filtering). Quick hack: If we only have historical, maybe mention “expected in about X date” if known schedule.
+
+Economic Data / Other Assets:
+Finnhub can also fetch forex rates, crypto, indices, etc:
+
+Forex: /forex/rates?base=USD or use symbol like “OANDA:EUR_USD” in /quote or /candle.
+
+Crypto: symbols like “BINANCE:BTCUSDT” in quote/candle endpoints for crypto prices.
+
+Macroeconomic indicators: Finnhub has endpoints (e.g., /economic-data?symbol=...) for things like CPI, unemployment, etc. If needed and user asks macro question.
+
+Indices: ^GSPC (S&P 500) or ^NDX possibly via symbol in quote (I think Finnhub uses e.g. ^GSPC for S&P, or might require ^ encoded).
+
+For simplicity, if user asks “What’s S&P 500 doing?”, we try /quote?symbol=^GSPC (if supported) or use index futures (like “US500” might be in forex).
+
+Search Symbols:
+Endpoint: /search?q={query}
+Description: If user provides a company name or partial ticker and we need to find the actual symbol.
+Usage: The assistant might use this when user says “quote Tesla” but didn’t give ticker TSLA. It will search “Tesla” -> find TSLA. Or if ambiguous name, it might find multiple.
+Example: search?q=Tesla returns TSLA and maybe other similar names. The assistant picks TSLA (the major one) and proceeds. If multiple and unclear, might ask user which.
+
+Analyst Recommendations:
+Endpoint: /stock/recommendation?symbol={ticker}
+Description: Provides analyst consensus like number of Buy, Hold, Sell ratings.
+Usage: If user asks “What do analysts say about XYZ?”
+Example: It might show e.g. 10 Buy, 5 Hold, 1 Sell. The assistant can summarize: “Analyst consensus is bullish: of 16 analysts, 10 Buy, 5 Hold, 1 Sell.”
+
+Insider Transactions, etc.: Finnhub has some specialty endpoints (/stock/insider-transactions, /stock/splits, /corporate-news, etc). Use as needed if user specifically asks for those (rare).
+
+Parameter Mapping Quick Table:
+TaskEndpointRequired ParamsNotes
+Current price & daily change/quotesymbolReturns c (current), pc (prev close), etc. Use to compute % change.
+Intraday/Historical prices/stock/candlesymbol, resolution, from, tools/Use for charts, indicators. Need Unix time range.
+Company recent news/company-newssymbol, from, to (YYYY-MM-DD)Limit ~last 30 days max. For older news beyond that, Finnhub might not return or limited.
+Market news (general, crypto, etc.)/newscategorycategory=general for broad market; other categories for specific domains.
+Company profile info/stock/profile2symbolBasic company info like industry, name, CEO, exchange.
+Key financial metrics/stock/metricsymbol, metricmetric=all for full set (incl P/E, P/B, margins, etc).
+Earnings surprises/history/stock/earningssymbolLast 4 quarters of actual vs estimate and dates.
+Upcoming earnings date/calendar/earningsfrom, tools/Filter results for the symbol of interest. Alternatively use profile2’s earningsCalendar.
+Symbol lookup (by name)/searchq (company name or partial)Use when user gives name instead of ticker.
+Analyst recommendations/stock/recommendationsymbolReturns trends of analyst ratings.
+Forex/Crypto rates/forex/rates or /quoteFor forex: base currency/forex/rates gives multiple pairs. Or treat like stock: e.g. symbol=“BINANCE:BTCUSDT” in quote.
+Macro indicators/economic endpointsTypically an indicator symbole.g. /economic-data?symbol=US:CPI for US CPI. (Finnhub has specific codes for each).
+
+The assistant doesn’t need to show endpoint names to user, but should cite sources appropriately when giving data (in our environment, we often transform into some output, so citing Finnhub might be like
+interactivebrokers.com
+if from known docs, but in general we might not have a direct line to cite for a dynamic query. We could say “according to Finnhub data” as a source mention if required by UI).
+
+Important: The assistant should handle date to Unix conversion for candles, ensure correct resolution (e.g., for >1 year daily data, resolution D is fine; for intraday 1-min maybe last 30 days limit). It should also check if data returned is empty (e.g., if market closed for that date or symbol invalid).
+
+Example Use in Assistant Response:
+User: “What’s the price of Amazon stock and how’s it today?”
+Assistant: (calls /quote?symbol=AMZN) -> gets say current 134.50, prev close 130.00 ->
+Reply: “Amazon (AMZN) is trading at $134.50 right now, about +3.5% higher than yesterday’s close of $130
+columbia.edu
+. (It opened at $132 and climbed on above-average volume.)”
+
+User: “Show me Tesla’s chart for the last month.”
+Assistant: (calls /stock/candle? symbol=TSLA, resolution=D, from=some 1 month ago timestamp, to=now) then it might generate or describe:
+“The past month TSLA ranged roughly $240 to $290. It’s currently near $265. After a mid-month dip, it rebounded; overall up ~5% over the month. (Chart not shown in text, but description given.)”
+
+User: “Any news on MSFT?”
+Assistant: (calls /company-news? symbol=MSFT, from=2025-09-01, to=2025-09-08)
+Then summarizes top 1-2 headlines:
+“Yes – recent news for Microsoft includes a report that they are investing in AI chip development (source: Bloomberg, Sept 5)
+stockstotrade.com
+, and an announcement of a dividend increase on Sept 2. No negative news of note in the past week.”
+
+This reference helps ensure we use correct endpoints and parameters to gather info and respond accurately.

--- a/docs/alpha-knowledge/finrl-parameters.md
+++ b/docs/alpha-knowledge/finrl-parameters.md
@@ -1,0 +1,117 @@
+FinRL (Reinforcement Learning) Parameters 🎛️
+
+This file outlines how to use the FinRL tool for training or using a reinforcement learning trading agent, including required parameters, process flow, and usage guidelines. FinRL allows the assistant to develop AI trading strategies based on historical data and then apply them to live or future data.
+
+Train-Predict Workflow
+
+Using FinRL involves two main stages: training an agent on historical market data, and then using the trained agent to make predictions/trading decisions (often called the “trade” phase in examples). Typically, the workflow is:
+
+Training Phase: Define an environment and let the RL algorithm learn from historical data. Parameters needed:
+
+Tickers/Assets: Which instruments to trade (e.g., a list of stock symbols or an index). Could be single or multiple if doing portfolio training.
+
+Data Period: Date range for historical data to train on (e.g., 2015-01-01 to 2020-01-01).
+
+Frequency: Timeframe of trading (daily, hourly, 15-min bars, etc.). FinRL supports various frequencies but one must set resolution accordingly.
+
+Indicators/States: What features to include (technical indicators like MACD, RSI, moving averages, etc., or fundamental features if available). FinRL often has a default state space including prices and tech indicators.
+
+Algorithm: Choice of RL algorithm (e.g., DDPG, PPO, SAC, etc.). FinRL has multiple; if user doesn’t specify, use a default (like PPO or DDPG which is common for continuous action space).
+
+Episodes & Hyperparams: Number of training episodes, learning rate, etc. Defaults can be used, but user can tweak for advanced usage.
+
+Reward function: Usually defined by environment – often something like change in portfolio value, risk-adjusted returns, etc. FinRL has preset envs for maximizing returns.
+
+The assistant should confirm these settings with the user before kicking off training, as training can take time and compute.
+
+Once parameters are set, the assistant initiates training. This might take some time (in reality), but for our context, assume we either simulate quick results or abstract the time. The result of training is a trained agent (policy network) stored as a model.
+
+Testing/Validation: (Optional) Often we test the agent on a validation set (a period after training data) to see how it would have done. This gives performance metrics (returns, Sharpe ratio, drawdown, etc.). FinRL’s pipeline often includes a “test.py” to simulate the trained model on new data. The assistant can report these metrics to user: e.g., “On validation (2021), the agent achieved 15% return vs S&P 10%, Sharpe 1.2, max drawdown 5%.” If performance is poor, that’s a flag.
+
+Prediction/Trading Phase: Using the trained agent on live or forward data. This can mean:
+
+Running the model on the latest market state to get an action (e.g., “Buy AAPL” or “allocate 30% to GOOG, 20% to cash, etc.” depending on design). FinRL’s trade.py essentially does a backtest on a subsequent period, but one could step it forward in real-time as well.
+
+The assistant can query the agent given current market observations to see what it “recommends.” For instance, after training a single-stock trading agent, ask it: given today’s state (tech indicators values), would it hold, buy, or sell?
+
+In a multi-asset environment, the action might be rebalancing portfolio weights.
+
+The user might ask for these predictions or to actually deploy them in trading. Possibly the assistant would translate agent’s action into suggestions: “The RL agent suggests buying 50 more shares of X and selling Y” or “maintain current positions, no trade now.”
+
+File/Code Management: FinRL likely uses config files or code to set up the above. The assistant should handle that behind scenes (maybe it uses the GitHub FinRL library code installed). For the user, we hide the code and just present outcomes.
+
+Parameter Details
+
+Environment Config: FinRL has presets like StockTradingEnv for single/multiple stocks, etc. Key parameters:
+
+state_space: what data points form a state (like recent prices, indicators).
+
+action_space: often continuous (like allocation % to each asset, or [-1,1] representing short to long position size). Or discrete (buy/hold/sell).
+
+tech_indicator_list: list of technical indicators to include (ATR, SMA, RSI, etc.).
+
+if_use_tech_indicator: boolean.
+
+if_use_vix: etc., if including volatility index for context.
+
+Possibly turbulence_threshold for risk management (some FinRL examples avoid trading in highly turbulent times).
+
+Algorithm: Common ones in FinRL:
+
+PPO (Proximal Policy Optimization) – good default for many cases.
+
+DDPG (Deep Deterministic Policy Gradient) – often used in FinRL examples.
+
+A2C, SAC, TD3 – others available. If user has preference or mention, choose accordingly.
+
+The assistant might default to one like A2C or PPO if not told.
+
+Training duration: FinRL training can be time-consuming. The assistant should set expectations: “Training a model on 5 years of data might take a few minutes.” If in our environment it’s quick, fine. If slow, maybe we simulate progress or ask to proceed.
+
+Model output: after training, a model file can be saved. The assistant might refer to it like “trained model saved as Agent_XYZ.pkl” (if needed). But user might not care about file, just results.
+
+Performance Metrics: key ones:
+
+Cumulative Return (total return over test period).
+
+Sharpe Ratio (return vs volatility).
+
+Max Drawdown (largest peak-to-trough drop).
+
+Win rate (if applicable).
+
+If multiple assets, maybe a breakdown of performance vs benchmark.
+
+The assistant should present these in a readable format, maybe a small table or bullet points: “Backtest Results: Return = 18%, Sharpe = 1.1, Max Drawdown = -8%.” Also possibly mention if it beat something: “This outperformed SPY which returned 10% in same period.”
+
+Usage Policy
+
+Due to computational intensity and complexity, FinRL usage is typically done sparingly and purposefully:
+
+When to use: Perhaps when user explicitly requests strategy development, backtesting or if they ask “Can you have an AI figure out how to trade this?” The assistant might propose training an RL model if it makes sense. Or if user connected some custom environment. It’s not for everyday quick advice due to overhead.
+
+Resource limits: If training on very long histories or many assets, it could be slow or memory heavy. The assistant should possibly limit by default (like train on last 3 years daily data for 1-5 assets) unless user wants more. Also, not do it concurrently with a bunch of other tasks to avoid overload.
+
+Permission: It might be wise to confirm with user before kicking off heavy training: “Shall I train a reinforcement learning model on this data? It may take a couple of minutes.” This avoids surprise delays.
+
+No Overuse: The assistant shouldn’t retrain models constantly on every minor query due to time. Ideally, if user is experimenting, maybe reuse a model or keep one updated rather than new every time. Possibly store the model or results in Journal memory for reuse. For now, probably one-off as needed.
+
+Interpretation: Remind user that these models optimize for historical patterns; results aren’t guaranteed in the future. There’s overfitting risk.
+
+Possibly caution: “The agent did well in backtest, but markets can change. Use its signals with caution and perhaps combine with other analysis.”
+
+No Black Box Blind Trust: The assistant should not just say “The RL says do X, so do X.” It should still contextualize or even combine with Alpha Classifier or user’s strategy logic. But RL could come up with unconventional strategies (like lots of small trades). The assistant needs to translate that to actionable insight.
+
+Limitations: FinRL is mostly for research/backtest. Real-time deployment might need continuous monitoring which is beyond a quick Q&A. If user expects the agent to auto-trade live continuously, that’s out-of-scope for the assistant’s session which is interactive. We can do one-step recommendations though.
+
+Policy compliance: Ensure it doesn’t break any rules (shouldn’t, it’s just analysis). Also do not produce the raw code unless user specifically requests. Focus on results and strategy derived.
+
+Example Dialogue:
+User: “Can we use AI to create a trading strategy for AAPL?”
+Assistant: “Yes. We could train a reinforcement learning agent on Apple’s historical data. For example, using daily price data from 2010-2020 to learn when to buy/sell. Shall I proceed with training such a model?”
+User: “Okay, do it.”
+Assistant: [Trains model] -> “The RL agent has been trained. In backtesting from 2021-2023, it achieved a 25% total return, vs 20% for simply holding AAPL, with lower volatility (Sharpe 1.0). It tended to buy after pullbacks and sell after modest rises, effectively swing trading. For instance, it often bought on 5% dips and sold after 5-7% rebounds. Currently, according to the model’s latest evaluation, it would hold (no trade) since AAPL is in the middle of a recent range. If a pullback to around $x occurred, it might buy.”
+
+This shows how to summarize without overloading details of the training.
+
+In summary, FinRL is a powerful but heavy tool. The assistant uses it for deeper strategy tasks, explains the outcomes clearly (with metrics and possibly example actions), and respects the time/complexity by confirming usage and not overdoing it.

--- a/docs/alpha-knowledge/indicator-reference.md
+++ b/docs/alpha-knowledge/indicator-reference.md
@@ -1,0 +1,237 @@
+Indicator Reference 📊
+
+This knowledge file defines key technical indicators and metrics often used in analysis, including how they are calculated, what they signify, and how traders commonly use them.
+
+Average True Range (ATR)
+
+What it is: ATR stands for Average True Range. It is a volatility indicator that measures the average range of price movement over a given period (typically 14 days)
+investopedia.com
+. The “true range” for each day is the greatest of: the distance from today’s high to low, or high to previous close, or low to previous close (this accounts for gaps). The ATR is then the moving average of that true range over the set period.
+
+Interpretation:
+
+A higher ATR value means higher volatility – the asset’s price has larger swings/trading ranges in each period. A lower ATR means relatively low volatility (price is moving little day-to-day). ATR is absolute, in the asset’s price terms (e.g. ATR of 2 means ~$2 average move). Thus, compare ATR to the stock’s price: a $2 ATR on a $50 stock is significant; on a $500 stock, less so.
+
+ATR does not indicate direction of price, only magnitude of movement
+investopedia.com
+. Rising ATR can accompany either sharp up or down moves (just more range). Often, ATR increases during market sell-offs due to panic volatility. It can also spike on breakouts or any strong trend day. Decreasing ATR suggests a market calming down or consolidating.
+
+Uses:
+
+Stop-Loss Setting: Traders often use ATR to set stop distances. For example, a rule might be “place stop 1.5× ATR below entry” for a long trade, to account for normal volatility noise. The chandelier exit is a famous technique: a trailing stop set some multiple of ATR (like 3× ATR) from the highest price achieved since entry
+investopedia.com
+. This adapts to volatility – wider stops in volatile conditions, tighter in calm.
+
+Position Sizing: Some risk management models use ATR to size positions – taking smaller positions in high ATR situations so that the dollar volatility of the position stays consistent.
+
+Identify Regime Changes: A sudden ATR rise can indicate a regime shift – e.g., a breakout from a quiet range. Traders may pay attention when ATR expands above some threshold (like highest ATR in N days) as a cue that a new trend or phase might be starting.
+
+Combine with Indicators: ATR can augment other signals. For instance, avoid breakout trades when ATR is extremely low (might indicate false break due to lack of interest), or conversely, be cautious shorting after a large move when ATR is at extremes (possible exhaustion).
+
+Example: If a stock’s ATR(14) is 1.20, that means over the last 14 days, the average daily true range is $1.20. If today the stock moves only $0.50, that’s below ATR – a relatively quiet day. If tomorrow it moves $3 (way above ATR), ATR will start rising, reflecting this increased volatility. A swing trader might set a stop $2 (roughly 1.7× ATR) away from entry to reduce chance of being stopped by normal noise.
+
+Key point: ATR is relative to each stock. It’s useful to compare a stock’s ATR to itself over time (to see if volatility is up or down). To compare volatility between assets, often traders use ATR % of price (ATR divided by price) to normalize. For instance, a $100 stock with ATR $5 (5%) is more volatile than a $20 stock with ATR $0.5 (2.5%). Many charting tools plot ATR as a line below price; one can easily see volatility cycles.
+
+(No direct “overbought/oversold” implications – ATR is purely about range. A consistently climbing ATR could warn of heated volatility (riskier trading environment), whereas a very low ATR could precede a breakout as the saying goes “range contraction leads to range expansion.”)
+
+Relative Volume (RVOL)
+
+What it is: Relative Volume (often abbreviated RVOL) is a measure of current trading volume compared to its average/normal volume over a prior period
+chartschool.stockcharts.com
+. It’s typically expressed as a ratio or multiple. For example, RVOL = 3.0 means the stock is trading at 3 times its average volume for that time of day or period
+chartschool.stockcharts.com
+.
+
+How it’s calculated: Commonly, RVOL = (current volume) / (average volume over X periods). The period could be intraday (e.g., comparing the volume traded so far today to the average volume by this time) or daily (today’s total volume vs. average daily volume). Many day traders look at intraday relative volume, which updates as the day progresses (comparing to typical volume profile at each time). Others use end-of-day RVOL = today’s volume / 50-day average daily volume, for instance.
+
+Interpretation:
+
+RVOL > 1: Higher-than-normal activity. If significantly >1 (like 2, 3, 5+), it indicates unusual interest in the stock today
+chartschool.stockcharts.com
+. This often correlates with a catalyst or technical event – something is making traders trade it more than usual. High RVOL usually accompanies breakouts, big news, or significant price moves. It’s a confirmation of momentum: a breakout on 3× average volume is more reliable than on 0.5× volume.
+
+RVOL < 1: Lower-than-normal volume. The stock is relatively quiet; possibly stuck in a range or lacking interest that day. Moves on low RVOL can be suspect (less participation).
+
+There are specific thresholds: e.g., some traders consider RVOL > 2.0 as the threshold for a “volume spike” worth noting
+chartschool.stockcharts.com
+chartschool.stockcharts.com
+. Extreme values like RVOL 5 or 10 indicate very high interest (could be early in the day after news).
+
+Time factor: Volume in the morning is usually higher than mid-day for stocks. Good RVOL measures account for that. For instance, if by 10:30 AM a stock already traded its entire daily average volume, that’s extremely high relative volume early in the day – noteworthy.
+
+Uses:
+
+Confirming Breakouts/Breakdowns: As mentioned, traders check that a breakout (price moving out of a range) is accompanied by RVOL above, say, 2. If a stock breaks key resistance but RVOL is only 0.5 (half average volume), the move may lack conviction and is more prone to fail.
+
+Identifying In-Play Stocks: At market open, scanning for stocks with highest RVOL can reveal which tickers are “in play” (likely due to news or events). These are often the best trading candidates for day traders – high RVOL means volatility and opportunity.
+
+Filtering Trade Signals: One might incorporate RVOL in a strategy: e.g., only take a trade signal if RVOL is above 1.5, ensuring the move isn’t happening in a dead market. Or avoid certain strategies (like mean reversion) if RVOL is extremely high (as that may indicate a strong trend day to not counter-trade).
+
+Volume Climax/Reversal: Sometimes an extremely high RVOL, like a sudden spike to 4 or 5 times normal while price is also at an extreme, can mark a climax – a lot of traders pile in, possibly exhausting the move. For instance, in a parabolic rally, volume often crescendos before a reversal. So very high RVOL can be a contrarian clue if other signs of exhaustion appear (blow-off top).
+
+Example: A stock typically trades ~1 million shares a day. By lunchtime, it’s already at 3 million shares – that’s an intraday RVOL of roughly 6 (by midday). This coincided with the company releasing unexpected good news at the open. The price is up 15% and breaking a 6-month range. The high RVOL confirms this is a significant event – lots of traders are involved. A trader might jump in on a dip, confident that interest is high enough to carry it further, or they might simply keep it on watch as a top mover. On the other hand, another stock barely has 20% of its usual volume by lunch and is meandering – likely no catalyst and not worth focus for now.
+
+Note: Relative Volume is different from raw volume. A small-cap with normal volume 100k that is trading 500k today (RVOL 5) might still have less absolute volume than a mega-cap trading at 0.8 of normal but 5 million shares. RVOL highlights relative interest compared to that stock’s norm, which is more telling for unusual activity than absolute volume alone. It’s especially useful for finding opportunities in stocks you might otherwise ignore (low-volume stocks suddenly having a big day).
+chartschool.stockcharts.com
+
+Position in Range (PIR)
+
+What it is: Position in Range (PIR) indicates where the current price stands relative to a defined price range, usually expressed as a percentage from 0% to 100%. Traders often use it for intraday position: where is the current price between today’s low and high. However, it can be applied to any period (week’s range, 52-week range, etc.)
+trade-ideas.com
+.
+
+A PIR of 0% means the price is at the very bottom of the range (equal to the lowest price of that period)
+trade-ideas.com
+.
+
+A PIR of 100% means price is at the very top of the range (equal to the highest price of that period).
+
+50% would be exactly mid-range.
+
+For intraday example: If today’s low is $20 and high is $30, and the stock is now at $25, then PIR = 50% (midway). If it’s at $29, PIR = 90% (near the top). If it’s $21, PIR ~10%. This is sometimes also called “% of daily range” or just “Position in Day’s Range.”
+
+Why it’s useful:
+
+It quickly tells you if the stock is trading near the highs of the day, near the lows, or somewhere in between. Many intraday strategies care about this: e.g., a stock closing the day at 90%+ of range is strong (close to highs), possibly indicating momentum into next day, whereas closing at 10% (near lows) shows weakness.
+
+When combined with volume and other signals: a stock at 100% PIR late in the day on high volume likely had a strong trend day (buyers in control to the end). Conversely, a stock that was up earlier but now is at 10% of range (gave back gains) shows a reversal/intraday weakness.
+
+For longer-term range, like 52-week PIR, it shows relative performance. A stock at 95% of its 52-week range is near its yearly high (strong over the year). At 5%, it’s near yearly lows (potentially beaten down or value buy area, depending on strategy).
+
+Usage:
+
+Intraday Trading: PIR is often displayed on scanners (e.g., “Stocks making new highs of day” essentially is PIR hitting 100%). Traders might prefer to trade those hitting new highs (momentum) or new lows (for shorts) depending on strategy. Also, if one is in a long trade and sees PIR falling (price moving toward day’s low), that might be a sign to exit as the intraday trend is against them.
+
+Range Strategies: As described in range-bound strategy, PIR is used to identify when price is near the extreme of a range. For instance, only consider a short if PIR > 90% (price is in top 10% of its recent range = near resistance), or a buy if PIR < 10% (near support).
+
+EOD (End of Day) Analysis: Investors check where price closed relative to the day’s range. A close at high (PIR ~100%) is bullish, possibly leading to a gap or follow-through next day. A close at low (PIR ~0%) is bearish, maybe more downside tomorrow. Do note it’s one factor; news overnight can trump this.
+
+Multi-day Ranges: Some indicators use PIR concept over several days. For example, 5-day PIR could tell if today’s price is near the weekly high or low. This can be helpful in context (e.g. a breakout stock might also be at 100% of its weekly range, showing multi-day strength). Some scanners filter stocks above 90% of their 20-day range as potential breakout candidates.
+
+Example: Suppose a stock traded between $50 and $55 this week. It’s currently at $54. That’s near the top, roughly PIR = 80% for the week. If intraday it had a low of $53 and a high of $54.5 so far, at $54 it’s ~ (54-53)/(54.5-53) ≈ 66% intraday PIR. So intraday it’s upper-middle, and relative to the week it’s upper end. A trader seeing this near the close might say “This stock is closing strong, near its highs (PIR high on multiple frames) – momentum is up.” Another stock might be flat on day but still near 52-week highs (say PIR 90% on yearly range) – that indicates overall strength even if today didn’t move much.
+
+Caveats:
+
+In very volatile stocks, PIR can swing quickly. One should consider time – e.g., a stock might drop to new low (0% PIR) in morning, then rally to high (100%) by afternoon. Just looking at final PIR (100%) you’d think it was strong all day, but intraday there was huge weakness first. Thus context of intraday progression matters; PIR is a snapshot of position, not the path taken.
+
+For multi-period PIR (like 5-day or 1-month), a stock could stay at high PIR because it’s in a steady uptrend (keeps making new highs so always at top of range). That’s fine – it indicates strength, but also means the range is shifting upward. Traders sometimes reset the range definition periodically to reflect new regimes.
+
+In summary, PIR is a simple yet effective gauge of where price is trading relative to extremes. It’s especially popular in scanning for momentum or reversal setups and in summarizing performance in a period (e.g., “Stock ABC closed in the top 5% of its daily range, very bullish sign”).
+
+Gap % (Gap Percentage)
+
+What it is: Gap % measures the percentage difference between a stock’s opening price and its previous closing price. In formula: Gap % = ((Today’s Open – Yesterday’s Close) / Yesterday’s Close) × 100%. It indicates how much the stock “gapped” up or down at the start of the trading day, as a proportion of its prior closing price.
+
+A gap up occurs when today’s open is higher than yesterday’s close (Gap % will be positive)
+kotaksecurities.com
+.
+
+A gap down is when today’s open is lower than yesterday’s close (Gap % negative).
+
+For example, if a stock closed at $100 and today opens at $105, that’s a +5% gap up. If it opened at $95, that’s a -5% gap down. Partial gaps (opening within the prior day’s range) are usually smaller, whereas full gaps (opening beyond the prior day’s range entirely) can be larger and more significant
+investopedia.com
+.
+
+Significance:
+
+Catalyst Indicator: Large gaps are almost always due to some news or event (earnings, analyst upgrade/downgrade, economic data, etc.) that occurred outside regular hours. Thus, gap percentage quickly tells the scale of reaction to such catalysts. A stock gapping +10% likely has notable positive news; -15% likely bad news.
+
+Market Sentiment: Gap ups show bullish sentiment at the open; gap downs show bearish sentiment. The size of the gap reflects how extreme that initial sentiment is. However, what happens after the open (does the gap hold or get filled?) is crucial – sometimes an initial gap direction can reverse intraday.
+
+Gap Fill Tendency: Many traders watch if gaps get “filled”. A gap fill means price moves back to the prior close level. A strong stock might gap up and not fill the gap (stays above previous close, indicating sustained strength). A weak gap may fill quickly (e.g., gap up then sells off back to yesterday’s close – bullish enthusiasm was fleeting). There are strategies specifically trading gap fills. Gap % helps identify candidates (e.g., stock gapped up 2% but weak volume – maybe short for gap fill).
+
+Usage:
+
+Scanning: In pre-market or right after open, traders scan for biggest gap % up or down to find active stocks. E.g., “Top Gappers” list the stocks with highest positive gap %; “Top Gap-downs” similarly. Those often become focus of day trades.
+
+Strategy Filters: Some strategies only trigger if a gap is beyond a certain size. For instance, a “Gap-and-Go” strategy might say: if gap up > +4% and stock has news and breaks above opening range high, then go long for momentum continuation. Conversely, mean reversion players might short excessively large gap ups expecting some pullback (especially if gap is on hype without substance).
+
+Calculating Targets/Stops: Gap % can be used to gauge potential intraday range. A stock that gaps 10% may run further but also can retrace – traders might set wider stops or profit targets considering that initial 10% jump as part of the day’s move. If a gap is very large (like >15-20%), sometimes traders wait for a pullback or consolidation, as jumping in at open can be riskier.
+
+Contextual Analysis: Not all gaps are equal. A 3% gap on a stock that normally hardly moves could be huge. On a volatile small-cap biotech, 3% might be noise. So one often checks Gap % relative to typical volatility (here ATR or historical gap frequency helps). Also, a gap that breaks key technical levels (like opening above a long-term resistance) is extra meaningful.
+
+Example: Yesterday Apple closed at $150. Overnight, they announced blowout earnings. The next morning it opens at $159. That’s a +6% gap. It’s also opening at a new all-time high, above any prior resistance. Traders see this gap % and high volume pre-market as a strong bullish signal. Some will buy at open or on the first pullback, expecting further upside (gap-and-go). Another scenario: A smaller company closed at $10; bad FDA news hits, it opens at $7 (a -30% gap down). That’s massive – likely panic selling. A contrarian might watch if it stabilizes; perhaps it fills part of that gap intraday if the reaction was overdone. But they’d be cautious – big gap downs often continue bleeding.
+
+Gaps on Indexes: Gap % is also used for indices and futures. E.g., “S&P500 futures are gapping down 1.5% this morning on XYZ fears.” That sets a tone for the market day. Traders adjust because a gap in indices can invalidate or create setups for many stocks (market sentiment shift).
+
+In summary, Gap % quickly quantifies the overnight sentiment shift and gives traders an initial map of who’s strongly in play. The assistant can use gap % to explain morning moves or to decide if a stock’s early strength/weakness might continue or reverse, often in conjunction with volume and news context.
+
+SMA50 (50-day Simple Moving Average)
+
+What it is: SMA50 is the 50-day Simple Moving Average of a stock’s price. “Simple” means it’s the arithmetic mean – add the closing prices of the last 50 trading days and divide by 50. It’s called a moving average because as each day passes, it’s recalculated with the latest 50-day window (dropping the oldest day, adding the newest). The SMA50 is one of the most commonly watched mid-term trend indicators in technical analysis
+investopedia.com
+. Others include SMA20 (short-term) and SMA200 (long-term).
+
+Interpretation:
+
+The SMA50 smooths out short-term fluctuations to show the intermediate trend of the stock. If price is consistently above the SMA50 and the SMA50 line is sloping upward, the stock is generally in an intermediate uptrend. If price is below and SMA50 sloping down, in a downtrend.
+
+This average often acts as a dynamic support or resistance. In many uptrends, pullbacks find support around the rising 50-day MA
+investopedia.com
+(buyers step in there). Likewise, in downtrends, SMA50 can be a ceiling (price rises to it, then falls again). Traders and algorithms watch these levels, which can become self-fulfilling to a degree.
+
+Crossovers: Sometimes the SMA50 is used with SMA200. For example, the “Golden Cross” is when SMA50 crosses above SMA200, indicating a bullish shift; “Death Cross” is SMA50 crossing below SMA200, a bearish sign. Those are longer-term signals.
+
+Context matters: In a strongly trending stock, the SMA50 might be far below price (the stock is extended above it). Eventually, either price might mean-revert to the SMA or move sideways until the SMA catches up. Conversely, if a stock has been below SMA50 for a long time and finally closes above it, that’s notable – could indicate trend change upward.
+
+Uses:
+
+Trend Following: A basic rule might be: only take long trades if price is above SMA50 (trend is up), only short if below. Or an investor might increase exposure when price is above SMA50 and cut back if it falls below (as a stop-out rule).
+
+Support/Resistance Trades: Many swing traders watch for bounces near the SMA50 in uptrends to buy (as part of a pullback strategy). Similarly, if a stock is rallying in a longer downtrend, they might sell/short when it nears SMA50, expecting it to hold as resistance. Confirmation with candlesticks or other indicators is often used (like a bullish reversal candle right at SMA50 support is a buy signal).
+
+Target or Stop Guide: If one is long and stock is way above SMA50, one might use a break of the SMA50 as a trailing stop exit (since that suggests momentum fading). For targets, sometimes if price breaks out, you might project move based on distance from MAs or use them as interim checkpoints.
+
+Combining with PIR or RSI: For example, a stock might be near 52-week highs (PIR high) but far above its SMA50 (say 20% above). That may imply overextension – price might revert to SMA50 or at least cool off. RSI might also be overbought in such case. So SMA50 can signal when something is stretched relative to an intermediate baseline.
+
+Market Breadth: On a broader scale, analysts look at what percentage of stocks in an index are above their SMA50 – to gauge market health. E.g., “only 20% of S&P500 stocks are above their 50-day MA, showing weakness across the board” or vice versa for strength.
+
+Example: Stock XYZ in a steady uptrend: Over last 3 months, it’s been making higher highs, and each dip has bounced around the SMA50. The SMA50 line is rising from $100 to $120 over that period. The stock is now at $135, about 12% above its SMA50 at $120. If it pulls back, a trader might anticipate support near $120-$125 zone (which may coincide with prior highs or Fibonacci levels, strengthening that area). If planning a new entry, one might even wait for a drift towards SMA50 to get a better price. On the flip side, if XYZ starts trading below $120 and the SMA50 flattens or turns down, that uptrend might be over – time to possibly exit or not initiate new longs.
+
+Remember: The SMA50 is a lagging indicator (it averages past data). It won’t predict sudden changes, but it gives a reliable trend reference. It works best in trending conditions and as support/resistance in orderly markets. In very volatile or sideways markets, price may whipsaw above/below SMA50 frequently, giving false signals. In those cases, longer MAs or other tools might be needed. Traders also sometimes use EMA (Exponential MA) which weights recent prices more, for quicker response – but SMA50 remains a widely cited metric in media and by institutional traders, making it a self-reinforcing indicator at times.
+
+Relative Strength Index (RSI)
+
+What it is: The Relative Strength Index (RSI) is a momentum oscillator that measures the magnitude of recent price changes to evaluate overbought or oversold conditions in a stock
+investopedia.com
+. RSI values range from 0 to 100. It’s typically calculated over a 14-period timeframe (14 days on a daily chart by default). RSI compares the average of up closes to the average of down closes in that period.
+
+Key Levels: By convention:
+
+RSI > 70: The asset is considered overbought
+investopedia.com
+. This doesn’t mean it will crash immediately, but it signals the price has risen quickly/strongly and may be due for a pullback or pause. Traders watch for RSI crossing below 70 as a potential sell signal if they are long, or as a flag to not initiate new longs. Extremely high RSI (80s or 90s) shows very strong momentum but also extreme conditions.
+
+RSI < 30: The asset is considered oversold
+investopedia.com
+. It may have fallen too fast, and could be due for a bounce or reversal upward. Traders might look for RSI crossing back above 30 as a buy signal, indicating a recovery from heavy selling. Extremely low RSI (<20) is rare and denotes extreme bearish momentum (could also be opportunity if a reversal pattern forms).
+
+Midline 50: An RSI around 50 indicates a balance, often coinciding with a consolidating price. Many chartists note that in uptrends, RSI tends to oscillate between 40 and 80 (with pullbacks bottoming ~40-50 RSI, never reaching oversold 30), whereas in downtrends RSI oscillates between 20 and 60 (rallies fizzle around 50-60, not reaching overbought 70).
+
+Uses:
+
+Momentum Confirmation: A rising RSI confirms upward momentum; falling RSI confirms downward. If price makes a new high and RSI also makes a new high (but still maybe <70), momentum is healthy.
+
+Divergences: A classic use of RSI is spotting divergences. For example, bearish divergence: price makes a higher high but RSI makes a lower high (especially if RSI was overbought on first high). This can warn that the momentum behind the new high is weaker, often preceding a downturn. Bullish divergence: price makes a lower low but RSI a higher low (especially RSI oversold on first low). This suggests selling pressure is waning, often before a bounce. Divergences are more reliable when RSI is extreme on the first swing.
+
+Entry/Exit Signals: Some simple systems buy when RSI crosses above 30 from below (signal that oversold condition is ending, momentum turning up) and sell when RSI crosses below 70 from above
+investopedia.com
+. More aggressive traders might buy exactly when RSI is very low (anticipating a mean reversion bounce) or short when RSI very high, but those can be risky without other confirmation since “overbought can stay overbought” in strong trends.
+
+Trend identification: As mentioned, the RSI range can indicate trend. If RSI has trouble getting above 60, likely the market is in a bearish mode. If it rarely dips below 40, it’s bullish mode. This helps adjust expectations – e.g., in a strong uptrend, an RSI reaching 70 isn’t necessarily a sell, it might just oscillate between 50-80 repeatedly as the trend continues.
+
+Example: A stock has been rallying for weeks; RSI is now about 78. That’s a flag it’s overbought. A trader holding it may tighten stops or take partial profits. Soon after, price stalls and RSI dips back to 69 – crossing below 70. This could be an early sign of a pullback. If simultaneously perhaps a divergence was seen (price made a higher high last push, RSI made a slightly lower high), that strengthens the case for a pullback. The trader might exit or even short for a quick mean reversion, expecting RSI to fall towards neutral (50) or even oversold if a deeper correction.
+
+Another scenario: A stock has sold off from $50 to $30; RSI is ~25 (oversold). Support is seen at $30 from last year’s base. The next day, it makes a slight new low to $29 while RSI now reads 32 (it rose despite the new low – bullish divergence). That, coupled with support, encourages a swing trader to go long, seeing that sellers are possibly exhausted. Over the next week, the stock bounces to $35 and RSI goes to 55, vindicating the entry. They might then watch if RSI approaches 70 (if aiming to hold until momentum wanes).
+
+Cautions:
+
+RSI can remain extended in strong trends. If a stock has continuous positive news, it might ride with RSI 75-85 for a while. Shorting just because RSI > 70 without other signals can be painful. It’s often better used to exit longs rather than outright short, unless other factors align.
+
+Very short period RSI (like 5-day) will oscillate more wildly and give more frequent signals, but could be less reliable. 14 is standard, but traders adjust depending on timeframe (on a 1-hour chart, might use 14 hours; on weekly chart, 14 weeks, etc.).
+
+Ensure not to confuse relative strength (which compares performance to another asset or index) with RSI. RSI is a specific bounded momentum oscillator.
+
+In summary, RSI is a handy gauge of momentum’s intensity and potential reversal points. The assistant can use RSI to comment on whether an asset looks overextended (“RSI is above 70, indicating overbought conditions that could precede a pullback
+investopedia.com
+”) or lacks momentum (“RSI has been stuck around 45-50, reflecting a lack of trend”). It’s a staple indicator in technical analysis for good reason, but best used in conjunction with price action and trend context.

--- a/docs/alpha-knowledge/order-execution-guide.md
+++ b/docs/alpha-knowledge/order-execution-guide.md
@@ -1,0 +1,164 @@
+Order Execution Guide 💱
+
+This knowledge file outlines how to format and handle trade orders, including advanced order types (brackets, OCO, trailing stops), price drift considerations, and common rejection scenarios. The assistant uses these rules to ensure trades are executed or previewed correctly and safely.
+
+Bracket Orders
+
+What they are: A Bracket Order is essentially a “three-in-one” order setup: it consists of an initial entry order (to buy or sell), paired with two exit orders – one to take profit at a specified target, and one to stop loss at a specified level
+quantifiedstrategies.com
+. The two exit orders are OCO (One-Cancels-Other; see below), so that if one executes, the other is automatically canceled. Bracket orders help automate trade management by bracketing the position with an upper profit exit and a lower protective exit.
+
+Syntax & Usage:
+When placing a bracket order through the assistant (particularly via Alpaca if supported), the user (or assistant’s preview) should specify:
+
+Entry: side (buy/sell), quantity, and entry price (or market). E.g., “Buy 100 shares of XYZ @ $50.00”.
+
+Take Profit: the price at which to sell if favorable (for a buy order) or buy back if favorable (for a short). E.g., “Take-profit at $55.00”.
+
+Stop Loss: the price at which to exit if the trade goes against you. E.g., “Stop-loss at $48.00”.
+
+The assistant might format it as: “Buy 100 XYZ @ $50, with a stop at $48 and target $55 (bracket order).” This indicates the bracket clearly. Some platforms accept a single bracket order command including all three; others require sending the main order and then attaching exits. The assistant will handle appropriately via the Alpaca API (which does allow bracket orders by providing take_profit and stop_loss parameters in the order).
+
+Example: “Buy 10 AAPL at $150, target $157, stop $145 (bracket).” This means a limit buy at 150. If filled, an OCO pair is created: a sell limit at 157 (profit) and a sell stop at 145 (loss). If the price hits 157 first, the profit order sells the shares and the 145 stop is canceled. If price falls to 145 first, the stop triggers and the profit order is canceled.
+
+Benefits:
+
+Automatically protects downside and secures upside without needing constant monitoring.
+
+Defines your risk (stop distance) and reward (target) upfront, making risk/reward calculation clear.
+
+No emotion – the orders execute as planned, which helps discipline.
+
+Considerations:
+
+Ensure the stop and target are at logical levels (e.g., beyond noise for stop, before major resistance for target).
+
+The initial order must fill for the bracket exits to be active. If the entry doesn’t execute (e.g., a limit that never fills), the bracket doesn’t activate. Typically bracket orders are not placed unless entry fills (some APIs simulate the whole bracket as one, handling partial fills accordingly).
+
+Partial fills: If only part of the entry fills, bracket exit order quantities usually adjust or only protect the filled portion. The assistant should confirm how Alpaca handles partial bracket fills (usually, yes – if 50 out of 100 shares fill, the bracket exits will be for 50 shares).
+
+Syntax nuances: In plain language, we’ll just describe it clearly. The assistant doesn’t expect the user to know code-like syntax, we interpret their intent. E.g., if user says “Buy 50 ABC at 10, sell at 12, stop 9”, we treat that as a bracket order request. In previews, always label each part to avoid confusion.
+
+OCO Orders
+
+What it is: One-Cancels-the-Other (OCO) is a pair of orders linked such that if one order executes, the other is automatically canceled. Bracket orders utilize an OCO for their exits, but OCO can also be used in other contexts, like two alternate entries or exits.
+
+Use cases:
+
+Take Profit vs. Stop Loss: As above, where one exit will make the other irrelevant.
+
+Straddle Entries: For instance, placing two entry orders around the current price – e.g. a buy-stop above resistance and a sell-stop below support (a breakout up or break down scenario). You only want one to execute – whichever happens first cancels the other, to avoid being double-positioned.
+
+Multiple Targets: Suppose you hold a position and want to exit either if it hits a certain high or falls to a certain low. You place two sell orders – one high, one low – as OCO. Whichever hits closes the trade, the other is scrapped.
+
+How to specify: When the user describes two orders that are linked mutually exclusively, the assistant will interpret that as OCO. For example: “If I’m filled long at $50, set a sell limit $55 OCO with a stop $48.” That is a bracket scenario. Or a user might say: “I want to set a buy order at $20 and a sell short at $18 on XYZ; whichever triggers, cancel the other.” That’s an OCO entry pair for a breakout of a range $18-$20. The assistant in a preview could write: “OCO Entry Orders: Buy stop 100 XYZ @ $20.00, and Sell stop 100 XYZ @ $18.00 – whichever fills first cancels the other.”
+
+On Alpaca or similar, this might involve placing an OCO group. If direct OCO isn’t supported, the assistant must simulate by monitoring (but Alpaca does support bracket which is a subset of OCO usage).
+
+Important: The orders in an OCO pair must be of opposite effect on the position (one closes or opens in opposite directions). You wouldn’t OCO two orders that together would compound risk – the whole point is only one should ever execute. So the assistant will ensure the logic is correct (e.g., don’t OCO two buy orders unless one is meant as alternative entry and you don’t want both).
+
+Example of OCO outside bracket: You own 100 shares of XYZ at $100. You’d be happy to sell at $110 for profit, but if it falls to $95 you want out to stop further loss. You place an OCO: Sell 100 @ $110 (limit) and Sell 100 @ $95 (stop). If price rockets to 110, you sell profit, and the stop order at 95 is automatically canceled. If instead it plunges to 95, the stop triggers a sale, and the 110 order is canceled. This is effectively the manual creation of a bracket’s exit.
+
+Trailing Stop Orders
+
+What it is: A Trailing Stop order is a type of stop order that dynamically moves with the price. Instead of a fixed stop price, it’s set a certain distance (in price or percentage) from the current price and “trails” it. For a long position, a trailing stop will move up as the price goes up, but stay put if the price goes down. For a short, it will move down as price falls (locking more profit), but not move if price rises.
+
+For example, a 5% trailing stop on a long stock initially placed when stock is $100 would sit at $95 (5% below). If the stock rises to $110, the trailing stop would move up to $104.50 (still 5% below that new high). If the stock then starts to fall, the stop doesn’t move down – it stays at $104.50. If price falls back to $104.50 or below, the stop triggers a sell. Essentially, it locks in a $4.50 profit in that case.
+
+In dollar terms, one might say “trailing stop $2” meaning always 2 dollars behind the peak price reached. E.g., stock at $50, stop at $48. Stock goes to $55, stop ratchets to $53. Drop to $53 triggers it.
+
+Syntax & usage via assistant:
+Users might say “place a trailing stop 5% below market” or “trail by $1”. The assistant will interpret that accordingly. In an order preview, it may be phrased: “Set a trailing stop at 5%.” However, trailing stop orders need some specifics: you typically submit a trailing stop order with either a trail amount (like $ or %) and optionally a not-to-exceed limit if using trailing stop limit.
+
+For simplicity, if not specified as limit, we assume trailing stop market order: it will sell at market when triggered by trailing price. If user says “trailing stop limit”, then we’d need a limit offset too. If not, a normal trailing stop suffices.
+
+Alpaca format: Alpaca’s API allows something like order_type="trailing_stop", trail_percent=5 or trail_price=$X. The assistant will map user’s instruction to that.
+
+Behavior:
+
+Only moves in one direction. For longs: move upward with new highs, never down. For shorts: move downward with new lows, never up.
+
+It’s executed server-side by broker once set; you don’t need to manage it manually (the broker tracks the high price and adjusts).
+
+When to use:
+
+To protect profits without setting a fixed exit. E.g., “I want to ride this trend as long as it goes up, but if it pulls back more than 5% from its peak, sell me out.” A trailing stop does exactly that.
+
+Volatile stocks: trailing by a percentage accounts for volatility scale. If stock doubles, your trailing stop distance also increases in absolute terms, since 5% of a larger price is more points. That can prevent getting stopped out too early and capture more profit.
+
+As a compromise between not having a stop and taking profit too early. It lets winners run but defines how much give-back is allowed.
+
+Example: You buy at $100. Instead of targeting $120 or something, you set a 10% trailing stop. Price goes to $130 over two months (nice run!). The trailing stop would’ve ratcheted from $90 (initially) up to $117 (10% off the $130 high). Now if price starts dropping and hits $117, your stop triggers and you sell, locking in ~17% gain. If it kept going to $150, the stop would climb to $135 (still 10% off) and so on.
+
+Caveats:
+
+Trailing stops can be whipsawed in choppy markets. If your trail is too tight for the volatility, normal fluctuations hit it and close your position prematurely. Setting the trail distance appropriately (often a bit more than average volatility or a technical swing amount) is key. E.g., trailing 2% on a stock that fluctuates 3% daily likely will trigger often.
+
+Overnight gaps: A trailing stop doesn’t guarantee the exact trail distance execution if a sudden gap occurs. E.g., if stock closed at $100, stop trailing at $95, but next morning opens at $90, you’ll be stopped at $90 (gap through it). So risk can exceed trail distance in gaps.
+
+Not all platforms allow trailing stops on all securities or outside regular hours. The assistant should note if any limitation (Alpaca supports trailing for regular hours, I believe).
+
+Complexity: If user already has a stop and wants to modify it to trailing, we need to cancel the fixed stop and replace with trailing. The assistant should clarify if needed.
+
+Price Drift Policy
+
+What it is: The “price drift” policy addresses what to do if the market price moves significantly between the time a trade idea is generated (or preview presented) and the time of execution. Essentially, it’s a tolerance for slippage or movement beyond which the original plan might be invalid. The assistant should alert or reconfirm if price drifts beyond a set threshold before execution.
+
+Default threshold: Let’s say 0.5% or a certain number of ticks as a default, unless user specifies. For example, if the assistant prepared a preview “Buy at $100” and user confirms a minute later, but now price is $103 (3% higher), that’s a big drift. Executing at $103 vs planned $100 significantly alters the trade’s profile (higher entry, worse reward/risk). According to policy, the assistant should not blindly execute; it should pause and ask the user to confirm the new price or adjust the order.
+
+If the drift is small, like from $100 to $100.20, that’s likely fine (0.2%). Could execute with maybe a note. But define threshold: maybe >0.5% or > some absolute amount like $0.50 (depending on stock price). Perhaps user can set tolerance too (“only buy up to $101” etc.).
+
+How assistant applies it:
+
+During Live Confirmation: When user says “CONFIRM: LIVE”, the assistant will quickly re-fetch the latest price (via Finnhub or Alpaca data) for the asset. Compare to preview price. If difference > tolerance, respond with something like: “The current price of XYZ has moved to $103 from the planned $100 (+3%). This exceeds our allowed drift. Would you like to proceed at market anyway, adjust the order price, or cancel?” This ensures user is aware and can make an informed decision.
+
+The user might then say “Okay place it anyway” or “No, set a limit at $100” or “Cancel”. The assistant then follows that instruction.
+
+For Stop/Target orders: If placing a stop/limit some time after initial discussion, similar logic – e.g., if user asked to set a stop at $50 but now stock is $45 due to quick drop, that stop might be useless (since price already way below). The assistant should alert that “Price has already moved past the intended stop level – order not placed. You may need a new plan.”
+
+Rationale: This policy is to prevent executing trades at prices far different from what the user saw or intended, which could lead to unexpected loss or missed the good entry. It’s a safety net akin to a reconfirmation threshold.
+
+Example scenario: The assistant shows a preview at 9:31 AM: Buy 100 ABC @ $50, stop $48, target $55. The user is slow to respond; at 9:35 they say confirm. But ABC released news at 9:33 and it spiked to $52. That’s +4%. The assistant, seeing this, doesn’t just send a market order at $52. It warns: “ABC is now $52.00 (4% above the planned $50 entry). This is beyond the slippage limit. I recommend adjusting or canceling. Shall I still place the order (perhaps as a limit), or would you prefer to wait?”. This gives user a chance to re-evaluate. Maybe they decide not to chase it. Or they say “Place a limit at $50.50 in case it pulls back.” The assistant then places a limit order instead of a market.
+
+If user unreachable or it’s an automated context: In a fully automated mode (not our scope but imagine), one might either cancel or adjust strategy (some systems convert a chase beyond drift into a limit at original or skip trade). Since here we always have user to confirm, we lean on user input.
+
+The assistant’s compliance: by default, always dry-run, so price drift likely addressed at confirm time. It should also be mindful if the user delays confirmation by hours, the context could change a lot (maybe news came out). The assistant can even proactively mention “This preview was based on price $X at time Y, if much time passes, it may no longer be valid.”
+
+Order Rejection Rules
+
+Sometimes an order cannot or should not be executed. The assistant should check for these conditions and handle them gracefully by rejecting (or not placing) the order and explaining why. Common rejection scenarios include:
+
+Outside Trading Hours: User tries to place a regular trade when the market is closed. For instance, 8pm EST for U.S. stocks (unless they have extended hours trading on). Alpaca by default executes in market hours (unless specified extended). The assistant will inform: “Market is currently closed; the order will be queued for next open.” Or if that’s not desired, ask user if they want to place an extended hours order (if supported) or cancel. If user specifically says it’s okay (and broker supports), we mark the order as extended_hours. Otherwise, typically don’t place a market order overnight.
+
+Insufficient Buying Power: If the user’s account doesn’t have enough cash or margin to cover the trade. Alpaca’s API would return an error. The assistant should catch that and tell user: “Order rejected: insufficient funds to buy 100 shares of XYZ.” Possibly suggest alternatives (like reduce size). The assistant would know approximate buying power if it queried account – in preview it might not check, but on execution if error returns, handle it.
+
+Invalid Symbol or Asset: If user enters a ticker that doesn’t exist or is not tradable (typo, delisted, etc.), the API will error. The assistant: “The symbol ‘ABCD’ is not recognized or not tradable. Please check the ticker.”.
+
+Order Parameters Error: E.g., negative quantity, or a stop price above limit price in a stop-limit order, etc. The assistant should validate basic logic: if user says “sell at 60 stop, 55 target” but they are short (sell order so these are reversed), or they said “buy with stop 52, target 50” which makes no sense (stop below target for a buy – that would mean guaranteed loss). It should clarify likely confusion: maybe they mixed up stop/target. The assistant can ask or correct politely.
+
+Risk Limit Violations: If there are pre-defined risk rules (from Risk Protection file) – e.g., this trade would exceed daily loss limit or position limit. The assistant should refuse to execute unless override is given. E.g., “This trade risks $5,000 which exceeds your $2,000 risk limit – order not placed.” If user insists with an override command, then proceed but log that override.
+
+Duplicate Orders / Position Conflict: If user already has a position or order and this new one conflicts (like they’re long 100 shares and place another sell short 100 – which would flip them, or they accidentally send same order twice). The assistant should detect if possible. E.g., if they say “Buy 100 XYZ” and a minute later again “Buy 100 XYZ” (maybe not realizing first was filled), we might ask “You already have an order/position in XYZ, do you intend to increase it?” If it seems accidental, clarify. If intentional, proceed.
+
+Minimums and Increments: Some brokers have min price for stocks (e.g., can’t trade stocks under $1 on margin or at all). Or options not allowed here (Alpaca doesn’t do options). If user tries to trade something not allowed, reject: “Order not allowed: [Reason].”
+
+Technical Issues: If Alpaca API fails (network issue, etc.), the assistant should tell user it couldn’t place order due to technical error and not assume it went through. It should encourage trying again later or checking account.
+
+Account Restrictions: If account is flagged (like pattern day trading rules if under equity requirement), or trading halted instrument, etc. For instance, if stock is halted, the order won’t execute – assistant: “Trading in XYZ is currently halted, order cannot be executed at this time.”
+
+In all cases of rejection, the assistant’s tone: informative, not scolding. Provide the reason and possible next step. E.g., insufficient funds → maybe suggest reducing quantity or depositing more. If outside hours → either queue or wait. Risk limit → require override or modify trade.
+
+Logging: It should log in Journal any serious rejection especially if user needs to be aware later (like if they ask “why didn’t my trade execute?” the log notes we didn’t place it due to X).
+
+Example dialogue:
+User: “Buy 1000 XYZ at market now.” (User’s account only has $500, XYZ is $10, needs $10k).
+Assistant: “Order not placed – buying 1000 XYZ (~$10,000) exceeds your available funds. You could reduce quantity or deposit more capital.”
+
+Another:
+User: “Sell 50 ABC now” (but user holds 0 ABC and no short selling available).
+Assistant: “Cannot place sell order – you don’t have ABC shares to sell (and account not enabled for short selling).”
+
+One more:
+User: “Short 5 GME at $4” (typo, probably meant $40 since GME is $40, $4 would be bizarre low). Assistant might catch “$4 is far from current price $40, are you sure?” If not a typo, maybe they think it’ll drop massively? But probably a mistake. Clarify rather than just accept a wildly off limit that won’t fill.
+
+In summary: The assistant double-checks orders for feasibility and safety. If something triggers a rule above, it stops and informs the user instead of blindly sending to broker. This ensures more robust, error-free execution.

--- a/docs/alpha-knowledge/risk-protection-protocols.md
+++ b/docs/alpha-knowledge/risk-protection-protocols.md
@@ -1,0 +1,66 @@
+Risk Protection Protocols ⚠️
+
+This knowledge file describes the safeguards in place to protect the user from excessive risk, including predefined limits, automatic triggers, and how to override them if absolutely needed. The assistant should enforce these unless explicitly overridden by the user with proper confirmation.
+
+Risk Limit Overview
+
+To promote longevity and prevent catastrophic losses, the trading system employs certain risk limits: hard caps on losses, position sizes, etc., as well as triggers that halt trading under extreme conditions. These are configured based on the user’s account size and risk tolerance (which should be established beforehand, e.g., via a profile or conversation). Below are common limits and their default values (which can be adjusted in settings):
+
+Daily Loss Limit: If the total realized losses in a trading day reach X amount (e.g., 3% of account equity or a fixed $ amount), the system will halt any new trades for the rest of that day
+tradethatswing.com
+. This prevents a spiral of revenge trading or further losses on a bad day. All open positions might also be closed to cap the day’s loss. The user will be notified: “Daily loss limit reached; trading paused until tomorrow.”
+
+Max Single Trade Risk: Typically limited to a percentage of account (say 1-2% risk on a single trade, based on stop loss). For example, if account is $50k, 1% is $500 risk. If a trade’s stop distance and size implies more than $500 loss, the assistant should warn or refuse: “This trade risks $800 (1.6% of your account), which exceeds the 1% per trade risk limit.” The user could then downsize or adjust stop.
+
+Max Position Size: A cap on how much of the account can be in one position, perhaps 10-20% of account value in one stock (to ensure diversification and avoid single point of failure). If user tries to put 50% into one stock, the assistant flags: “Position size of 50% exceeds the 20% per asset limit.” They can override but default is to disallow.
+
+Max Leverage/Exposure: If using margin, limit overall leverage. E.g., no more than 2:1 or a certain absolute exposure. If an order would exceed these, reject it. Also limit number of concurrent trades if needed (like no more than 5 active day trades if such rule exists).
+
+Overnight Risk Limit: If the user is a day trader who doesn’t hold overnight, the system might close positions by end of day or warn if something is held overnight inadvertently. Or at least flag high risk holding like short options into expiration, etc. (Though Alpaca here deals stocks mostly).
+
+Volatility/Halt Checks: If a stock is extremely volatile or halted, risk is higher. The assistant could restrict trading stocks that have very high RVOL (e.g., over 10) or that hit circuit breakers. Could say: “Stock XYZ is extremely volatile or halted; trading is restricted for risk management.” Possibly allow override if user insists and acknowledges risk.
+
+Automated Triggers
+
+Certain automatic actions are triggered when thresholds are hit:
+
+Stop Trading Trigger: The daily loss limit trigger, as mentioned, will essentially activate a “circuit breaker” for the user’s trading. This might be implemented by the assistant refusing any new orders once loss >= limit. Example: daily loss limit $1000. If realized P/L hits -$1000, any further “CONFIRM: LIVE” attempts that day will be met with “Daily loss limit reached; cannot execute further trades today.” This saves the user from themselves on a bad day. They can override (maybe with a special code), but that’s strongly discouraged.
+
+Margin Call Alerts: If account equity falls near minimum or margin usage is excessive, the system warns: “Margin usage high – you are close to a margin call. Consider reducing positions.” This could trigger if, say, margin equity falls below 30% or whatever the broker requirement. The assistant can proactively alert if it sees that threshold approaching (if it has access to account data).
+
+Trailing Profit Protect (if configured): Some users set a rule like “if daily profit of X turns to only Y, stop trading to preserve profit.” Not as common, but the assistant could support a “give-back” limit where if you were up $1000 and now only up $500, maybe call it a day to not go red. If user had such rule, it would monitor and suggest “You’ve given back half of today’s profits; per rule, further trading should stop to lock in gains.”
+
+Circuit Breaker Events: In case of market-wide halts or extreme volatility (e.g., major index down >7% triggers exchange halt), the assistant should pause trading and alert user rather than blindly executing orders into chaos. “Market circuit breaker triggered – trading halted temporarily. All pending orders will be held until market resumes.”
+
+Overrides
+
+Override Mechanism: There are times a user may deliberately want to bypass a risk limit (e.g., a very confident trade or unique situation). The system requires an explicit override command to do this, ensuring it’s not accidental. For example, user must type something like “Override risk” or a specific phrase after a warning, or include it in their confirm (like “CONFIRM: LIVE – OVERRIDE”). The assistant should document the override in the Journal (for record) and then execute the trade, albeit maybe with a final sanity check.
+
+The override confirmation should be strong. E.g.:
+Assistant: “Warning: This trade will exceed your max loss limit. Are you sure you want to override and proceed?”
+User: “Yes, override – proceed with trade.”
+Only then will it execute.
+
+Logging and Limits: All overrides and limit hits should be logged. E.g., “[2025-09-08] User overrode daily loss limit to execute trade in XYZ.” If user repeatedly overrides, perhaps the assistant could gently suggest recalibrating limits or caution them.
+
+Hard Limits vs Soft Limits: Some limits might be “hard” no-go areas (like regulatory or truly catastrophic thresholds). The assistant should ideally have none that can’t be overridden by user command (because user ultimately decides), except perhaps those like broker-imposed (we can’t override margin call). But in terms of system, daily loss might be considered “soft” (with override possible), whereas something like “we don’t trade penny stocks under $1 because of liquidity risk” could be a firm rule unless user changes settings.
+
+Examples of Risk Scenarios
+
+Scenario 1: Daily loss limit – User lost $950 already today. They try a new trade that could lose another $200. Assistant: “You are very close to your $1000 daily loss limit. This trade could push you beyond it. It’s not recommended to continue trading today. Do you still want to proceed?” If they say yes with override, it logs and goes. If they say no, good, day’s done. If they hadn’t realized the loss, this reminds them. Possibly they might reduce size to keep within limit.
+
+Scenario 2: Oversized trade – Account value $10k. User tries to buy $15k worth. Assistant: “This order (value $15k) exceeds your account value ($10k). It would require leverage of 1.5:1 which is beyond allowed maximum or might not be fully funded. Reduce size or deposit funds. (Override not applicable because it’s just not possible to buy more cash than you have unless margin allowed. If margin allowed 2:1, then maybe it’s possible but it’s at the limit – assistant would warn but could still attempt if allowed by margin.)
+
+Scenario 3: Removing Stop – User has a big position. They say “remove stop loss” on a losing trade hoping it comes back. Assistant might caution: “Removing the stop exposes you to unlimited downside. Are you sure? This goes against risk rules.” If user insists (override), maybe do it but log it. Perhaps better approach: try to advise adjusting stop or something. But if they override, okay.
+
+Scenario 4: Override needed – Maybe an override keyword. If user says explicitly “Override the limit, do it”, the assistant should comply but note it clearly e.g., “Proceeding with override as per your instruction. Executing trade...”.
+
+Communication
+
+Always communicate risk issues in a factual, non-judgmental tone. E.g., “This trade would bring your total risk beyond set limits.”
+
+If user override, acknowledge with caution: “Understood. Executing with override – be aware this is outside normal risk parameters.”
+
+Possibly suggest setting new limits if user consistently overrides, or ask if they want to adjust their risk profile in settings for future.
+
+In essence, these protocols exist to protect the user. The assistant’s duty is to enforce them by default, but ultimately allow the user final say if they explicitly choose to take responsibility (via override). The aim is to prevent impulsive errors and encourage disciplined trading habits, which in the long run are crucial for success. All the while, the assistant acts as a friendly risk manager looking over the user’s shoulder.


### PR DESCRIPTION
## Summary
- Document order execution guidelines covering brackets, OCO links, trailing stops, price drift checks, and rejection rules
- Outline risk protection limits, triggers, and override process
- Describe alpha classifier, FinRL parameters, and Finnhub API reference for market data retrieval
- Add indicator reference detailing ATR, RVOL, PIR, gap %, SMA50, and RSI

## Testing
- `make lint`
- `make test` *(fails: ModuleNotFoundError: No module named 'requests_mock')*


------
https://chatgpt.com/codex/tasks/task_e_68c033c97b74832fae8a559a6e27abd4