### PR TITLE
docs: add strategy reference knowledge file

### DIFF
--- a/docs/alpha-knowledge/strategy-reference.md
+++ b/docs/alpha-knowledge/strategy-reference.md
@@ -1,0 +1,246 @@
+Strategy Reference 📈
+
+This knowledge file provides an overview of common trading strategies the assistant can reference or explain to users. Each strategy is defined, with key characteristics and usage notes.
+
+Pullback Strategy
+
+Definition: A pullback strategy involves entering a trade after a temporary dip against the prevailing uptrend (or a bounce in a downtrend), assuming the overall trend will resume
+investopedia.com
+. In simpler terms, traders wait for a price that’s been rising to “pull back” slightly, then buy at that lower price (or shorting a brief rise in a falling market) before the trend continues.
+
+Characteristics:
+
+Occurs during a clear trend (bullish for buy pullbacks, bearish for short pullbacks). The price retraces a portion of the recent move, typically to a support level or moving average (e.g. 50-day MA often serves as support in pullbacks
+investopedia.com
+).
+
+Pullbacks are usually short-lived, lasting only a few bars or sessions, and not breaking the overall trend structure. They often end at technical support like a trendline, previous resistance-turned-support, or a Fibonacci retracement level (common pullback zones are 38.2% or 50% retracements of the prior swing).
+
+Traders use other indicators to judge if it’s a true pullback vs. a reversal. For example, during a pullback in an uptrend, RSI often dips out of overbought territory (below 70) giving room for the next rally, but stays above oversold. Volume may decrease during the pullback, then increase as the trend resumes, indicating the pullback was merely a pause
+investopedia.com
+.
+
+Usage:
+
+Entry: Often via limit orders at known support or a technical level (like a moving average). For instance, “buy the dip” near the trend’s support. Candlestick patterns (e.g. a bullish engulfing off support) can act as entry confirmation.
+
+Stop-Loss: Placed just below the pullback low (for bullish pullback trades). This ensures if the price continues down (potentially a true reversal), risk is limited.
+
+Take-Profit: Often aim to exit at or slightly beyond the prior swing high (for a long pullback trade) as the trend makes a new high. Alternatively, use trailing stops to ride the trend if expecting a larger move.
+
+Example: Stock X is in an uptrend from $50 to $60. It then pulls back to ~$55, near the 20-day moving average. Bullish signals (e.g. RSI holding above 40, lighter volume on the dip) suggest it’s a healthy pullback. A trader buys around $55 with a stop at $53 (just under recent low) and targets a move back above $60.
+
+Pros & Cons:
+
+Pros: Pullbacks offer better entry prices than chasing the trend high, and risk can be lower since you’re nearer support. They also allow joining established trends which have momentum.
+
+Cons: A pullback can turn into a full reversal unexpectedly. It can be tricky to differentiate a normal retracement from a trend change in real-time
+investopedia.com
+. Thus, confirmation and risk management are key. Also, in very strong trends, pullbacks might be shallow or brief – easy to miss if too conservative on entry.
+
+Breakout Strategy
+
+Definition: A breakout strategy focuses on entering trades when the price breaks out of a defined range or chart pattern, often accompanied by increased volume
+investopedia.com
+. A breakout occurs when price moves beyond a key level of resistance (for upside breakouts) or support (for downside breakouts, often called “breakdown”). The idea is that once such a level is breached, the price will continue to trend in that direction, fueled by momentum and new participation.
+
+Characteristics:
+
+Key Levels: Breakouts typically happen from a trading range or consolidation. For example, a stock might be stuck between $100–$105 for weeks; an upside breakout is a move above $105. Chart patterns that produce breakouts include rectangles (ranges), triangles, flags, head-and-shoulders (neckline break), etc.
+
+Volume Spike: A valid breakout is usually accompanied by a surge in volume
+investopedia.com
+. High volume confirms that many traders are involved and adds credibility that the price will likely continue in the breakout direction (as opposed to a false breakout/fakeout).
+
+Volatility Expansion: When price was in a tight range, volatility was low. A breakout often marks the start of higher volatility movement
+investopedia.com
+. Traders anticipate this expansion to profit from the larger swing.
+
+Follow-through: After breaking a level, that prior resistance may become new support (and vice versa for breakdowns). Successful breakouts often retest the breakout level briefly and then continue. Failed breakouts (“fakeouts”) will fall back into the range, which is a warning sign. Waiting for a close beyond the level, or a retest, can filter out some fakeouts
+investopedia.com
+.
+
+Usage:
+
+Entry: Enter as soon as price clearly moves past the breakout point (e.g., a few ticks above resistance for a long trade). More cautious traders wait for a retest of the broken level (price breaking out, then coming back slightly to test the level, then rising again) as confirmation. One might set buy stop orders just above the resistance to catch the breakout in real-time.
+
+Stop-Loss: For an upside breakout, a stop is usually placed just below the broken resistance (which should now act as support). This way, if the breakout fails and price falls back, the trade is exited quickly. For example, if resistance was at $50, and price breaks to $51, one might stop out at $49.50 if it reverses, as falling back into the range could signal a trap.
+
+Take-Profit: Targets can be estimated by the size of the prior range or pattern. E.g., if the trading range was $5 wide, a successful breakout might travel roughly $5 beyond the breakout point (a measured move). Some use technical projections (like the height of a chart pattern added to breakout point
+investopedia.com
+). Also, if volume and momentum remain strong, traders may choose to ride the trend and trail a stop rather than setting a fixed target.
+
+Example: A stock has been in a $20–$22 range for a month on low volume. Suddenly it moves to $22.50 on a big volume spike after a news release – an upside breakout. A breakout trader buys in at $22.50, sets a stop at ~$21.90 (below old resistance ~$22 now support), and might target ~$24–$25 (range width $2 added to $22 breakout level, and accounting for momentum possibly overshooting). The trade is monitored for continuous high volume and no reversal back below $22.
+
+Pros & Cons:
+
+Pros: Breakouts can lead to large quick gains as new trends form – you’re potentially at the start of a major move. It capitalizes on building momentum and crowd psychology (people rushing in once a level breaks). It’s also straightforward to identify key levels beforehand.
+
+Cons: False breakouts are common, especially in choppy or news-driven markets. Entering on a breakout can sometimes mean buying near a short-term top if it immediately reverses. Managing risk is crucial; a tight stop can often get hit in a volatile retest even if the breakout eventually works. Also, breakouts with insufficient volume or in overextended markets can fail – one needs to assess context (e.g. breakout occurring far above previous trend might be exhaustion rather than start of trend).
+
+(See also Breakdown below for the bearish counterpart of breakouts.)
+
+Breakdown Strategy
+
+Definition: A breakdown is the bearish counterpart to a breakout. It occurs when price falls below a defined support level or trading range floor, signaling a potential move lower. A breakdown strategy involves shorting or selling when this downward break happens, expecting further decline
+investopedia.com
+. Essentially, it’s profiting from an escape of price to the downside out of a consolidation or pattern.
+
+Characteristics:
+
+Similar to upside breakouts, breakdowns come from trading ranges or chart patterns, but the move is downward. Key support levels (a price floor that had held multiple times) get breached. For example, if a stock repeatedly bounced at $50, a drop to $49 on high volume would be a breakdown of that support.
+
+Volume and Momentum: A convincing breakdown usually has high volume selling and a widening range of price movement downward. Increased volume indicates many participants are selling or shorting, adding conviction to the move
+investopedia.com
+. Momentum oscillators may show strong downward momentum (e.g. RSI rapidly dropping, but often not yet oversold at the moment of break).
+
+Follow-through Behavior: After breaking support, that old support can act as new resistance on bounces. Traders watch for any pullback up to the breakdown level as a chance to initiate or add to shorts (“throwback” move). If the price quickly reclaims the support level, that warns of a false breakdown. Confirming closes below support or a lack of bounce back is a good sign for the bears.
+
+Usage:
+
+Entry: Typically, traders will short sell as price clearly breaks below support or a pattern neckline. They might use a sell stop order just below the support level to automatically trigger a short when the breakdown happens. Another entry is on the brief rebound (if any) to the broken level – entering on that test of new resistance.
+
+Stop-Loss: Set just above the broken support (now resistance). This keeps risk tight in case the breakdown fails. For example, if support was at $100 and it broke to $98, a stop could be placed at ~$101 – if price goes back above $100, the breakdown is likely void.
+
+Take-Profit: Measure the depth of the prior range/pattern to project a target. If the stock was oscillating in a $5 range before, one might expect roughly a $5 drop below support in a clean breakdown (subject to other supports below). Also, watch for next major support zones (previous lows, Fibonacci levels) as potential targets or areas to take profit. Some traders cover (take profit on shorts) in stages as the price falls and indicators get oversold (e.g. RSI approaching <30).
+
+Example: A cryptocurrency trades between $30,000 and $32,000 for weeks. A series of bad news causes a surge in sell volume and it cracks $30,000, falling to $29,000. A breakdown trader shorts near $30K on the break, maybe gets filled at $29.5K, places a stop at $30.5K (above the broken level). They target a move to ~$28K (range height $2K subtracted from $30K support gives $28K target). As it falls, volume remains high. When price hits $28K and RSI is ~25 (oversold), they cover some profits.
+
+Pros & Cons:
+
+Pros: As with breakouts, breakdowns can result in quick, significant moves – beneficial for fast profits. They allow traders to get in at the start of a potential downtrend or big selloff. Risk can be well-defined (above the broken support). For those comfortable shorting, it’s a strategic way to profit in falling markets, not just rising ones.
+
+Cons: False breakdowns (price dips below support then recovers) can trigger shorts then reverse, causing losses. Market makers or algorithms sometimes push price just below a level to trigger stop orders, then price bounces – this whipsaw is painful for breakdown traders. Additionally, shorting has its own risks (short squeezes, margin requirements, etc.). One must also be cautious of breakdowns that occur on very news-sensitive events; an oversold bounce or reversal could be sharp if interpretation changes. Good risk management and confirmation signals (like volume or retests) help mitigate these cons.
+
+Range-Bound (Mean Reversion) Strategy
+
+Definition: A range-bound strategy aims to exploit a market that is trading in a sideways range by buying near the range’s support (bottom) and selling near resistance (top), or conversely shorting at resistance and covering at support. Essentially, assume the status quo (the range) will continue until a clear breakout/breakdown occurs. It’s a form of mean reversion trading – expecting price to revert back toward the middle of the range after stretching to an extreme.
+
+Characteristics:
+
+Identifiable Horizontal Levels: The asset’s price oscillates between a high and low boundary multiple times, establishing a clear channel or rectangle over time
+investopedia.com
+investopedia.com
+. For example, bouncing between $45 and $50 repeatedly forms a $45–$50 range.
+
+Low Trend Strength: Trend indicators (like ADX – Average Directional Index) are usually low in ranges, indicating no strong uptrend or downtrend. The market lacks directional momentum.
+
+Overbought/Oversold Oscillators: Indicators like RSI or Stochastic often swing repeatedly between high and low extremes, lining up with the range tops and bottoms. Traders use these to time entries: e.g. RSI near 30 at range support (oversold → buy), RSI near 70 at range resistance (overbought → sell)
+investopedia.com
+.
+
+Volume Patterns: Volume might decline inside the range except for spikes at the extremes where reversals happen (as buyers defend support, sellers defend resistance). If volume is fairly even throughout, it suggests equilibrium – typical of ranges. A significant volume surge accompanying a move through a range boundary could signal the range is ending (breaking out).
+
+Usage:
+
+Entry: Buy when price is at or slightly above established support, ideally after confirming it’s holding (for instance, a bounce off support or a bullish candlestick pattern at support). Short or sell when price is at or slightly below resistance, after signs of rejection (e.g. bearish candle at the top). Patience is key – wait for the price to actually get near the extremes. As a guideline, some traders require price to be in the lower 20% of the range to consider it “at support” for a buy, and upper 20% for “at resistance” to short.
+
+Stop-Loss: Place stops just outside the range. For a long trade at support, stop a bit below the support level; for a short at resistance, stop above the resistance. For example, if range support is around $100, you might stop at $98 – if it hits, that suggests a breakdown, and you exit to avoid a larger loss. This way a true breakout/breakdown will trigger the stop and protect you from staying on the wrong side.
+
+Take-Profit: Target the opposite side of the range. If you bought near $100 support, aim to sell near the $120 resistance. Some may take partial profits at the mid-point of the range or other interim levels, but generally the thesis is it will swing fully across. Alternatively, one can trail a stop once price moves favorably – but since the expectation is mean reversion, not a new trend, it’s common to just use fixed targets at known levels.
+
+Example: EUR/USD has been ranging between 1.10 and 1.12 for months due to balanced economic outlook. A range trader will buy around 1.105 or lower (support area near 1.10) whenever it dips and shows stabilization, with a stop at 1.095 (just under support). They’ll then sell around 1.118–1.12 (near resistance), possibly setting a limit order to take profit there. Conversely, if it approaches 1.12 and fails to break out, they might initiate a short at 1.119 with a stop at 1.125, targeting a drop back to ~1.105. They avoid trading in the middle of the range, as it’s less predictable there.
+
+Pros & Cons:
+
+Pros: In well-defined ranges, this strategy has a high win rate because you’re essentially “buying low, selling high” in a market that repeatedly allows it. Risk is relatively small (distance from extreme to breakout point) compared to reward (distance across the range)
+investopedia.com
+investopedia.com
+. It’s also somewhat easier to automate or set alerts for (when price hits known levels).
+
+Cons: The biggest risk is a breakout or breakdown – one trade can hit a stop and potentially reverse the profit of several small wins. Ranges don’t last forever; being late to recognize a breaking trend can be costly. Also, in extended ranges, there can be false breakouts that whipsaw (price peeks past support/resistance then returns). Ranges can also be messy with mid-range volatility, so discipline is needed to only trade at edges. Additionally, range strategies might underperform or sit idle during trending markets, as one could miss out on big trend moves by always expecting reversion.
+
+Catalyst News Strategy
+
+Definition: A catalyst strategy centers on trading around significant news or events (“catalysts”) that can drive a large price move in a stock. Examples of catalysts include earnings releases, economic reports, product launches, FDA approvals (for biotech), mergers/acquisitions, etc. The idea is that a fresh catalyst can suddenly shift supply-demand, causing a breakout from previous price behavior. Traders either position ahead of an anticipated catalyst (speculative) or react quickly after news to capture the momentum it creates
+stockstotrade.com
+.
+
+Characteristics:
+
+High Volatility on Catalyst: When a true catalyst hits, the stock often gaps (opens significantly up or down) and experiences heavy volume and volatility following the news
+investopedia.com
+. For instance, an earnings surprise might gap a stock up 10% at open with 5× normal volume.
+
+Directional Bias from News: The content of the catalyst often gives a directional bias – positive news (beat earnings, new contract win) tends to spark rallies; negative news (missed earnings, regulatory crackdowns) causes selloffs. However, how far it goes can depend on market positioning (short interest, expectations). Sometimes even good news can lead to drops if it was expected or “priced in”.
+
+Short-Lived or Multi-Day Moves: Some catalysts lead to one-day pops/drops and then mean-revert (especially minor news or when outcome was expected). Major surprises can kick off multi-day or multi-week trends as analysts upgrade/downgrade and more investors re-price the asset. The trader must judge if the catalyst has long-lasting implications or is a quick sentiment blip.
+
+Premarket/After-hours activity: Many catalysts occur outside regular trading hours (e.g. earnings announced after market close). Thus, significant price movement may happen in premarket/aftermarket. Catalyst traders often monitor these sessions for price action and initial reaction to news.
+
+Usage:
+
+Pre-catalyst Positioning: Some experienced traders take positions before a known scheduled catalyst (like an earnings date) based on predictions (fundamental analysis, whispers, etc.). This is risky – essentially a bet on outcome. They might also hedge (options or smaller size) due to uncertainty. Example: buying a biotech stock ahead of an FDA decision if you have conviction it’ll be positive. If correct, the payoff can be huge on the gap. If wrong, losses can be large too. This approach is speculative and not recommended without solid rationale and risk control.
+
+Post-catalyst Reaction: A more common strategy is to trade after the news is out:
+
+Momentum Trade: Jump in the direction of the news once it’s confirmed significant. For instance, company X blows out earnings, stock gaps up and keeps rising – a momentum trader might buy shortly after open and ride the intra-day uptrend, exiting by day’s end or when momentum fades. Quick execution and tight stops (in case of reversal) are key.
+
+Fade the Overreaction: If a catalyst move seems extreme relative to the news, contrarian traders may fade it (short after a huge gap up, or buy after a crash), expecting a retracement once the initial euphoria/panic settles. This requires experience, as strong catalysts can keep running (don’t step in front of a freight train).
+
+Second-Day Play: Often, the day after the catalyst is telling. Some wait for the initial day’s range to form, then trade break of that range on day 2, as a continuation or reversal signal. E.g., if day 1 of news gaps up and then closes off highs, day 2 breaking the day1 low could signal a fill-the-gap move down. Conversely, holding gains and breaking higher day2 might continue the trend.
+
+Information Gathering: When news hits, quickly assess what it is. Read the earnings summary, or the press release highlights. Identify if it beats or misses expectations, or if guidance is raised/lowered. The faster (and more accurately) one interprets the catalyst, the better the trade decision. The assistant can help here by summarizing news (via Finnhub’s news API or similar) and highlighting key points (e.g. “EPS beat by 20%, raised full-year outlook – very positive catalyst”).
+
+Risk Management: Catalyst moves can be wild; use appropriate position sizing. Also consider wider stops due to volatility, or using options to define risk. If trading after a gap, recognize that liquidity might be thinner and spreads wider, so limit orders and caution are advised.
+
+Example: Company ABC announces before open that its drug trial succeeded (huge positive). The stock, which closed at $10, now indicates $18 premarket. At open it surges to $20 on massive volume. A momentum trader buys the opening consolidation at $18 with a stop at $17 (volatile, so wide stop ~5-6%), and sells into strength at $22 by noon as momentum shows first signs of slowing. Alternatively, a fade trader might wait for it to hit, say, $25 by late morning in a frenzy, notice RSI is 85 and volume peaking, then short with stop $26, aiming for a pullback to ~$20. Each approach depends on reading the catalyst’s impact.
+
+Pros & Cons:
+
+Pros: Catalysts are what make stocks move big – trading them can be very profitable in short time. They provide clear fundamental reason for a move, which often means there’s follow-through (not random drift). For informed traders, they can offer edge (e.g. understanding an earnings report better than others). Also, catalyst trades don’t rely on long periods – they are event-driven, so opportunity arises regularly (earnings seasons, news cycles, etc.).
+
+Cons: High volatility = high risk. One bad news gap against you can blow past stops (gapping through stop levels). Reaction can be unpredictable: sometimes good news sees price drop (sell-the-news effect)
+stockstotrade.com
+. Fast reaction needed – algorithms often trade news in milliseconds, so retail traders are inherently a bit behind the initial move. Slippage is common. Additionally, if one is on the wrong side of a catalyst (especially pre-positioned), losses can be severe. It requires discipline to cut losses fast if the market’s interpretation doesn’t match yours.
+
+RL-Blend Strategy
+
+Definition: The RL-Blend strategy is a hybrid approach that combines insights from a Reinforcement Learning (RL) agent with traditional trading strategy signals. The idea is to leverage a trained AI model’s recommendations (which might capture complex patterns or optimal policies) and blend them with human-defined strategies (like those above) to make trading decisions. This isn’t a single classical strategy, but rather a framework to improve strategy performance by integrating AI-driven “alpha” with rule-based logic.
+
+Concept:
+Imagine you have an RL model that outputs a score or action suggestion for an asset (like buy, hold, or sell), based on myriad inputs (price history, indicators, etc.) that it learned from training. Instead of blindly following it, you blend it with a strategy. For example, the RL might signal a high probability of upward movement; you then check if technical strategy (pullback, breakout, etc.) also aligns. Only when both agree (or the combination meets certain criteria) do you execute a trade. This can filter out false signals from either side.
+
+Characteristics:
+
+Quantitative Model Output: The RL agent provides a quantitative assessment, such as an alpha score (expected return or confidence in a move) or direct actions. It’s data-driven and adaptive. However, it might not explicitly account for recent news or intuitive support/resistance that a human strategy would, hence the benefit of blending.
+
+Rule-based Overlay: The human strategy part imposes interpretable rules – e.g., “Only go long if RL is positive and we are above the 50-day MA and a pullback condition is met.” The rules ensure trades occur in contexts the human deems favorable, acting as a sanity check on the AI.
+
+Dynamic Weighting: Sometimes the blend is a weighted combination. For instance, one could compute a composite signal = (Strategy Signal * 50%) + (RL Model Signal * 50%). If composite > threshold, then trade. More simply, one might just require consensus: Alpha Classifier (AI) says “strong buy” and strategy also says “setup is bullish” = proceed. If they conflict, either no trade or lower confidence.
+
+Continuous Learning: The RL component can be retrained periodically on new data, which means the blend strategy might evolve. The historical performance of the blend vs individual parts can be tracked to adjust the weighting or rules.
+
+Usage:
+
+Scenario – Trend Confirmation: Say the RL agent has learned to predict short-term price direction and gives a score 0 to 1 (1 meaning high confidence in price increase). A blend strategy might be: if RL score > 0.8 (very bullish) and the market is in an uptrend (e.g., price above SMA50 and making higher highs), then take a long position. The RL provides a timing/selection edge, and the trend filter ensures you align with broader momentum.
+
+Scenario – Mean Reversion Check: Conversely, if using a mean reversion base strategy (range trading), you might use RL to avoid bad trades. For instance, normally you’d buy at range support, but if the RL agent strongly predicts a breakdown (maybe it recognized a regime change), you skip that buy trade. Here the RL acts as a risk filter to avoid ranges about to break.
+
+Position Sizing: Another blending approach is to use RL’s confidence to size positions. E.g., a breakout strategy triggers a trade; if the RL alpha score is moderately bullish, you take a normal size. If RL score is extremely bullish, you might take a larger size (since two systems strongly agree). If RL is lukewarm or opposite, either take a much smaller size or stand aside.
+
+Example: You have a pullback strategy that usually buys dips in an uptrend. Incorporating RL, you feed recent market data into the RL model which outputs a probability of the uptrend continuing. One day, stock XYZ pulls back to support – normally a buy by your rules – but the RL agent, perhaps sensing unusual weakness, outputs only a 0.3 (30% chance of upside). The blend strategy says skip this trade (or be very cautious). Indeed, maybe news or subtle signals (captured by the RL through training) indicated a higher chance of breakdown this time. By avoiding it, you saved a loss. Alternatively, when both indicate a high-probability opportunity, you trade confidently.
+
+Pros & Cons:
+
+Pros:
+
+Enhanced Accuracy: By requiring dual agreement (model + strategy), you potentially reduce false signals. The RL can capture non-linear patterns humans miss, and the human strategy can ensure basic sensible conditions (like trend or risk management) are met.
+
+Adaptability: The RL part can adapt to changing market conditions faster than fixed rules, so the blend can adjust over time (especially if retrained regularly).
+
+Reduced Overfitting: Pure ML models sometimes overfit or give erratic signals in real market use; blending with stable rules can temper that, making performance more robust.
+
+Explainability: The presence of a rule-based component helps keep some interpretability. You can explain trades by the rule part even if the RL is a black box, which can be important for user trust.
+
+Cons:
+
+Complexity: Now you have two systems to maintain – the strategy and the model. If a trade does poorly, diagnosing whether the rules or the model was at fault can be complicated. Tuning the blend (like threshold or weighting) adds another layer of parameters.
+
+Conflicting Signals: There will be times the two disagree. That could mean fewer trades (which might be good or bad for performance). If not carefully handled, it might also mean missing out on some good trades because one part was wrong. It requires analyzing historically how to best handle disagreements (maybe one of them tends to be right more often in conflict).
+
+Development & Data Needs: An RL model needs substantial data and training infrastructure. It’s not a static strategy – you must retrain and ensure it remains effective. If the model degrades and you don’t notice, it could hurt results. Also, blending might mask when the model’s edge decays (since rules might carry performance or vice versa).
+
+Interpretation: When a blended strategy gives a signal, attributing it can be difficult (“the model liked it and the rules agreed, but why exactly did the model like it?”). For users wanting clear rationale, you’d mostly lean on the rule explanation. Pure discretionary traders might also have a learning curve trusting an AI component’s judgment.
+
+In summary, RL-Blend strategies aim to get the “best of both worlds” – the intuition and proven patterns from traditional strategies, and the pattern-recognition power of machine learning. The assistant can utilize this by consulting its Alpha Classifier (or other model outputs) in conjunction with strategy rules before advising trades, thereby providing a more robust recommendation.


### PR DESCRIPTION
## Summary
- add strategy reference knowledge base covering pullback, breakout, breakdown, range-bound, catalyst news, and RL-Blend strategies

## Testing
- `pre-commit run --files docs/alpha-knowledge/strategy-reference.md docs/alpha-knowledge/indicator-reference.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c03e3b6590832fbb7e3ec9183823f0