### PR TITLE
Document cancel order request semantics

### DIFF
--- a/app.py
+++ b/app.py
@@ -114,6 +114,8 @@ def cancel_order(order_id: str, x_api_key: Optional[str] = Header(None)):
     check_key(x_api_key)
 
     tc = trading_client()
+    # The TradingClient handles targeting the v2 endpoint and omits the
+    # request body, which matches the behaviour expected by Alpaca's REST API.
     tc.cancel_order_by_id(order_id)
 
     # The Alpaca REST API returns HTTP 204 with an empty body on success, so

--- a/tests/trading/trading_client/test_order_routes.py
+++ b/tests/trading/trading_client/test_order_routes.py
@@ -326,6 +326,8 @@ def test_cancel_order_by_id(reqmock, trading_client: TradingClient):
     trading_client.cancel_order_by_id(order_id)
 
     assert reqmock.called_once
+    request = reqmock.request_history[0]
+    assert request.body is None
 
 
 def test_cancel_order_throws_uncancelable_error(reqmock, trading_client: TradingClient):


### PR DESCRIPTION
## Summary
- document that the TradingClient handles the v2 cancel endpoint without sending a payload
- extend the trading client tests to ensure no request body is sent when cancelling an order

## Testing
- pytest tests/trading/trading_client/test_order_routes.py::test_cancel_order_by_id

------
https://chatgpt.com/codex/tasks/task_e_68cde35acf94832fb25a5be55a4f36bc