### PR TITLE
Return HTTP 204 from cancel order endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,7 +4,7 @@ import re
 from datetime import datetime
 from typing import List, Optional
 from fastapi import FastAPI, Header, HTTPException, Query, Path
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, Response
 from pydantic import BaseModel
 from alpaca.trading.client import TradingClient
 from alpaca.trading.enums import OrderSide, TimeInForce
@@ -105,11 +105,19 @@ def get_order(order_id: str, x_api_key: Optional[str] = Header(None)):
     o = tc.get_order_by_id(order_id)
     return o.model_dump() if hasattr(o, "model_dump") else o.__dict__
 
-@app.delete("/v1/orders/{order_id}")
+@app.delete(
+    "/v1/orders/{order_id}",
+    status_code=204,
+    summary="Cancel order",
+    response_description="Order cancelled",
+)
 def cancel_order(order_id: str, x_api_key: Optional[str] = Header(None)):
     check_key(x_api_key)
     tc = trading_client()
-    return tc.cancel_order(order_id)
+    tc.cancel_order(order_id)
+
+    # The decorator defines a 204 status code, so simply return an empty response.
+    return Response(status_code=204)
 
 # -- Account
 @app.get("/v1/account")

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -180,7 +180,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/HTTPValidationError'
     delete:
-      summary: Cancel Order
+      summary: Cancel order
       operationId: cancel_order_v1_orders__order_id__delete
       parameters:
       - name: order_id
@@ -198,11 +198,8 @@ paths:
           - type: 'null'
           title: X-Api-Key
       responses:
-        '200':
-          description: Successful Response
-          content:
-            application/json:
-              schema: {}
+        '204':
+          description: Order cancelled
         '422':
           description: Validation Error
           content:


### PR DESCRIPTION
## Summary
- ensure the cancel order route returns an empty HTTP 204 response that matches the Alpaca API
- adjust the OpenAPI document to describe the 204 response and updated summary

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'requests_mock')*

------
https://chatgpt.com/codex/tasks/task_e_68ce1c2346d0832f86544b4b7977fb0d