### PR TITLE
Add production server to OpenAPI spec

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -2,6 +2,9 @@ openapi: 3.1.0
 info:
   title: Alpaca Wrapper
   version: 1.0.0
+servers:
+  - url: https://alpaca-py-production.up.railway.app
+    description: Production deployment
 paths:
   /v1/order/bracket:
     post:


### PR DESCRIPTION
## Summary
- add the production deployment URL to the OpenAPI `servers` list so docs point to the hosted API

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ce23d96c08832fa7c965c52c967782