### PR TITLE
Add alpha latest routing and validation schemas

### DIFF
--- a/docs/alpha_latest/alpaca_order_rules.json
+++ b/docs/alpha_latest/alpaca_order_rules.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AlpacaOrderRules",
+  "type": "object",
+  "properties": {
+    "allowed_order_types": { "type": "array", "items": { "type": "string" }, "default": ["market","limit","stop","stop_limit"] },
+    "allowed_time_in_force": { "type": "array", "items": { "type": "string" }, "default": ["day","gtc"] },
+    "rth": {
+      "type": "object",
+      "properties": {
+        "brackets_allowed": { "type": "boolean", "default": true },
+        "trailing_allowed": { "type": "boolean", "default": true }
+      },
+      "additionalProperties": false
+    },
+    "ext": {
+      "type": "object",
+      "properties": {
+        "supported_order_types": { "type": "array", "items": { "type": "string" }, "default": ["limit"] },
+        "brackets_allowed": { "type": "boolean", "default": false },
+        "trailing_allowed": { "type": "boolean", "default": false },
+        "tif": { "type": "string", "enum": ["day"] }
+      },
+      "additionalProperties": false
+    },
+    "price_rules": {
+      "type": "object",
+      "properties": {
+        "limit_requires_price": { "type": "boolean", "default": true },
+        "stop_requires_stop_price": { "type": "boolean", "default": true },
+        "stop_limit_requires_both": { "type": "boolean", "default": true }
+      },
+      "additionalProperties": false
+    },
+    "quantity_rules": {
+      "type": "object",
+      "properties": {
+        "min_qty": { "type": "number", "default": 1 },
+        "integer_only": { "type": "boolean", "default": true }
+      },
+      "additionalProperties": false
+    },
+    "idempotency": {
+      "type": "object",
+      "properties": {
+        "client_order_id_required_for_retries": { "type": "boolean", "default": true }
+      },
+      "additionalProperties": false
+    }
+  },
+  "required": ["allowed_order_types","allowed_time_in_force","rth","ext","price_rules","quantity_rules","idempotency"],
+  "additionalProperties": false
+}

--- a/docs/alpha_latest/classifier_gate.md
+++ b/docs/alpha_latest/classifier_gate.md
@@ -1,0 +1,9 @@
+# Classifier Gate
+
+**Purpose:** Deterministic gating of trade setups before simulation or execution.
+
+- **Threshold:** Proceed only if `score ≥ 0.70`.
+- **Labels:** Accept if `label ∈ {StrongBuy, Buy}`; otherwise **PASS**.
+- **Action on fail:** Do not simulate or trade. Create a `watchlist_entry` with `{strategy, symbol, reason, added_ts}`.
+- **Re-check:** If the setup changes materially (RVOL, PIR, news), re-run the classifier and re-evaluate.
+- **Journal:** Record the gate decision and inputs in the journal entry.

--- a/docs/alpha_latest/classifier_schema.json
+++ b/docs/alpha_latest/classifier_schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AlphaClassifierOutput",
+  "type": "object",
+  "properties": {
+    "score": { "type": "number", "minimum": 0, "maximum": 1 },
+    "label": { "type": "string", "enum": ["StrongBuy","Buy","Neutral","Sell","StrongSell"] },
+    "features": {
+      "type": "object",
+      "properties": {
+        "trend": { "type": "number" },
+        "rvol": { "type": "number" },
+        "pir": { "type": "number" },
+        "atr": { "type": "number" },
+        "rsi": { "type": "number" },
+        "news_flags": { "type": "array", "items": { "type": "string" } }
+      },
+      "additionalProperties": true
+    },
+    "rationale": { "type": "string" }
+  },
+  "required": ["score","label"],
+  "additionalProperties": false
+}

--- a/docs/alpha_latest/earnings_policy.md
+++ b/docs/alpha_latest/earnings_policy.md
@@ -1,0 +1,9 @@
+# Earnings Proximity Policy
+
+**Objective:** Reduce event risk around earnings.
+
+- **Block new swing entries** if the next earnings event is within **< 48 hours**.
+- **Reduce size (0.5x)** if earnings are **48–72 hours** away and user insists.
+- **Post-earnings:** If positive surprise + gap up + holds above open/VWAP with RVOL ≥ 2, allow pullback entry; set `SL` under pullback; stage TP to gap high then measured move.
+- **Existing positions:** Manage risk; allow trims/tighten stops into earnings per plan.
+- **Journal:** Note the earnings timestamp used and decision rationale.

--- a/docs/alpha_latest/error_taxonomy.md
+++ b/docs/alpha_latest/error_taxonomy.md
@@ -1,0 +1,22 @@
+# Error Taxonomy (General)
+
+Use this taxonomy to resolve issues deterministically.
+
+## Categories
+- **AUTH:** Missing/invalid credentials.
+- **VALIDATION:** Missing/invalid params, bad dates/symbols.
+- **SESSION:** Market closed/halts/EXT rules violated.
+- **RATE_LIMIT:** 429 responses from providers.
+- **RETRYABLE:** Transient 5xx/timeouts.
+- **UNSUPPORTED:** Mode/endpoint not available.
+
+## Remedies
+- **AUTH:** Supply correct key; stop after failure.
+- **VALIDATION:** Report exact field; suggest fix; do not guess.
+- **SESSION:** Fail closed; propose RTH queue or refresh.
+- **RATE_LIMIT:** Honor reset headers; jitter; single retry; no fan‑out.
+- **RETRYABLE:** Retry once; then degrade (e.g., Classifier‑only).
+- **UNSUPPORTED:** Suggest supported path (e.g., local vs remote).
+
+## Ladder
+1) Identify root cause → 2) Adjust if certain → 3) Retry once if allowed → 4) PASS with precise next step.

--- a/docs/alpha_latest/move_explanation.schema.json
+++ b/docs/alpha_latest/move_explanation.schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "MoveExplanation",
+  "type": "object",
+  "properties": {
+    "symbol": { "type": "string" },
+    "magnitude_pct": { "type": "number" },
+    "catalysts": { "type": "array", "items": { "type": "string" } },
+    "timeframe": { "type": "string", "enum": ["intraday","session","multi-day"] },
+    "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+    "suggestion": { "type": "string" }
+  },
+  "required": ["symbol","magnitude_pct","timeframe","confidence"],
+  "additionalProperties": false
+}

--- a/docs/alpha_latest/order_validation.schema.json
+++ b/docs/alpha_latest/order_validation.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "OrderValidation",
+  "type": "object",
+  "properties": {
+    "ok": { "type": "boolean" },
+    "order_intent": {
+      "type": "object",
+      "properties": {
+        "action": { "type": "string", "enum": ["buy","sell"] },
+        "symbol": { "type": "string" },
+        "qty": { "type": "number" },
+        "type": { "type": "string", "enum": ["market","limit","stop","stop_limit"] },
+        "price": { "type": ["number","null"] },
+        "stop_price": { "type": ["number","null"] },
+        "tif": { "type": "string", "enum": ["day","gtc"] },
+        "session": { "type": "string", "enum": ["RTH","EXT"] }
+      },
+      "required": ["action","symbol","qty","type","tif","session"],
+      "additionalProperties": false
+    },
+    "reasons": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  },
+  "required": ["ok","order_intent","reasons"],
+  "additionalProperties": false
+}

--- a/docs/alpha_latest/preflight_check.schema.json
+++ b/docs/alpha_latest/preflight_check.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "PreflightCheck",
+  "type": "object",
+  "properties": {
+    "balances": {
+      "type": "object",
+      "properties": {
+        "equity": { "type": "number" },
+        "buying_power": { "type": "number" },
+        "cash": { "type": "number" }
+      },
+      "required": ["equity","buying_power","cash"],
+      "additionalProperties": false
+    },
+    "positions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "symbol": { "type": "string" },
+          "qty": { "type": "number" },
+          "avg_price": { "type": "number" }
+        },
+        "required": ["symbol","qty","avg_price"],
+        "additionalProperties": false
+      }
+    },
+    "earnings_proximity_hours": { "type": "number" },
+    "market_session": { "type": "string", "enum": ["RTH","EXT","CLOSED","HALTED"] },
+    "violations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "code": { "type": "string" },
+          "message": { "type": "string" },
+          "blocking": { "type": "boolean" }
+        },
+        "required": ["code","message","blocking"],
+        "additionalProperties": false
+      }
+    }
+  },
+  "required": ["balances","positions","market_session","violations"],
+  "additionalProperties": false
+}

--- a/docs/alpha_latest/route_decision.schema.json
+++ b/docs/alpha_latest/route_decision.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "RouteDecision",
+  "type": "object",
+  "properties": {
+    "target": { "type": "string", "enum": ["alpaca","finnhub","classifier","finrl","internal","journal","none"] },
+    "resolvedAlias": { "type": "string" },
+    "fallback": { "type": "boolean", "default": false },
+    "reason": { "type": "string" }
+  },
+  "required": ["target","resolvedAlias"],
+  "additionalProperties": false
+}

--- a/docs/alpha_latest/sessions_holidays.md
+++ b/docs/alpha_latest/sessions_holidays.md
@@ -1,0 +1,10 @@
+# Sessions & Holidays Policy
+
+**Scope:** US equities (NYSE/Nasdaq).
+
+- **Session states:** `RTH` (09:30–16:00 Eastern), `EXT` (pre/post as supported by broker), `CLOSED`, `HALTED`.
+- **Blockers:** Do not place new entries when `CLOSED` or `HALTED`.
+- **Pricing:** Prefer limit orders in fast tape; no market orders outside RTH.
+- **Detection:** Use broker/exchange status from connected actions when available; otherwise derive from timestamp and weekday.
+- **Holidays:** Maintain a holiday list in journal/config; if unknown, fail closed and ask to confirm session.
+- **Queueing:** If user intends EXT but symbol/session not eligible, propose RTH queue or adjust.

--- a/docs/alpha_latest/trade_preview.schema.json
+++ b/docs/alpha_latest/trade_preview.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "TradePreview",
+  "type": "object",
+  "properties": {
+    "mode": { "type": "string", "enum": ["DRY_RUN","LIVE"] },
+    "action": { "type": "string", "enum": ["buy","sell"] },
+    "symbol": { "type": "string" },
+    "qty": { "type": "number" },
+    "order": {
+      "type": "object",
+      "properties": {
+        "type": { "type": "string", "enum": ["limit","market","stop","stop_limit"] },
+        "price": { "type": ["number","null"] },
+        "tif": { "type": "string", "enum": ["day","gtc"] },
+        "session": { "type": "string", "enum": ["RTH","EXT"] }
+      },
+      "required": ["type","tif","session"],
+      "additionalProperties": false
+    },
+    "exits": {
+      "type": "object",
+      "properties": {
+        "stop": { "type": ["number","null"] },
+        "target": { "type": ["number","null"] },
+        "trailing": {
+          "type": "object",
+          "properties": {
+            "type": { "type": "string", "enum": ["percent","price"] },
+            "value": { "type": ["number","null"] }
+          },
+          "required": ["type","value"],
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "risk": {
+      "type": "object",
+      "properties": {
+        "perTradePct": { "type": "number" },
+        "rr": { "type": "number" }
+      },
+      "additionalProperties": false
+    },
+    "assumptions": { "type": "array", "items": { "type": "string" } }
+  },
+  "required": ["mode","action","symbol","qty","order"],
+  "additionalProperties": false
+}

--- a/docs/alpha_latest/watchlist_entry.schema.json
+++ b/docs/alpha_latest/watchlist_entry.schema.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "WatchlistEntry",
+  "type": "object",
+  "properties": {
+    "strategy": { "type": "string" },
+    "symbol": { "type": "string" },
+    "reason": { "type": "string" },
+    "added_ts": { "type": "string", "format": "date-time" }
+  },
+  "required": ["strategy","symbol","reason","added_ts"],
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Summary
- add JSON schemas that describe alpha order flows, validations, routing, and trade preview objects
- document classifier gating rules along with session/holiday, earnings, and error-handling policies

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68cffd3e4da0832f9bf4ac0403a27da1