### PR TITLE
docs: set 2 percent default risk and add watchlist workflow

### DIFF
--- a/docs/alpha_latest/strategy_reference.md
+++ b/docs/alpha_latest/strategy_reference.md
@@ -20,7 +20,7 @@ Purpose: deterministic, machine-readable playbook for the trading assistant. The
 2) **Earnings proximity**: block new swing entries if next earnings < **48h**; if 48–72h and user insists, size at **0.5×**.  
 3) **Quote staleness**: use price only if provider timestamp age ≤ **10s**; otherwise refresh before sizing/limits.  
 4) **EXT rules**: no brackets/trailing in extended hours; use **limit + Day + extended** only.  
-5) **Risk skeleton**: per‑trade risk ≤ **1% equity**; per‑name exposure ≤ **20%**; daily loss halt **−5%**.
+5) **Risk skeleton**: per‑trade risk ≤ **2% equity** (default); per‑name exposure ≤ **20% equity**; daily loss halt **−5%**.
 
 ---
 
@@ -275,5 +275,6 @@ If a symbol **nearly** meets criteria but fails one or more minimums, **do not s
 
 ## Implementation Hints
 
-- Keep human text concise; produce a **`trade_preview` JSON** alongside human preview for any simulated plan.  
+- Keep human text concise; produce a **`trade_preview` JSON** alongside human preview for any simulated plan.
+- Default **per‑trade risk = 2% of equity** unless the user specifies otherwise.
 - If **any** gate fails (classifier, earnings window, session rules, quote TTL, order validation), **fail closed** and provide the next precise step (e.g., add to watchlist, refresh quote, switch to RTH).

--- a/docs/alpha_latest/trade_preview.schema.json
+++ b/docs/alpha_latest/trade_preview.schema.json
@@ -38,7 +38,7 @@
     "risk": {
       "type": "object",
       "properties": {
-        "perTradePct": { "type": "number" },
+        "perTradePct": { "type": "number", "default": 0.02 },
         "rr": { "type": "number" }
       },
       "additionalProperties": false

--- a/docs/alpha_latest/watchlist_workflow.md
+++ b/docs/alpha_latest/watchlist_workflow.md
@@ -1,0 +1,69 @@
+# Watchlist Workflow
+
+**Purpose:** Centralise opportunity discovery and tracking. Maintain strategy‑specific watchlists; surface high‑conviction, capital‑aware candidates.
+
+## Sources
+- **Classifier:** score setups; gate at `score ≥ 0.70` and labels {StrongBuy, Buy}.
+- **Quotes/Candles:** Finnhub for price/volume; respect TTL rules.
+- **FinRL (optional/consent):** signals/backtests to support conviction.
+- **Account/Positions:** Alpaca balances + current holdings.
+- **Journal:** persistent store for watchlist entries and daily summaries.
+
+## Data Contract
+Use `watchlist_entry.schema.json` for entries:  
+`{ "strategy": "<name>", "symbol": "<TICKER>", "reason": "<short>", "added_ts": "<ISO8601>" }`.
+
+## Daily Session Routine
+1) **Load prior entries** from Journal; prune stale (TTL 10 sessions by default).
+2) **Scan candidates**:
+   - Screen by strategy minima (e.g., Breakout: RVOL≥1.5, PIR≥80; Pullback: RSI 35–55, RVOL 0.8–1.2).
+   - Run **Classifier**; tag as:
+     - `active` if gate passes (score/label OK),
+     - `monitor` if close‑miss on minima (e.g., RVOL short, PIR < threshold).
+3) **Cross‑check account**:
+   - Compare against **balances/buying power** and **positions**.
+   - If adding a new trade exceeds per‑name exposure (20%) or daily halt threshold, **downgrade** priority.
+4) **Risk & session gates**:
+   - Default **per‑trade risk = 2% of equity**; compute size from planned SL distance.
+   - RTH: allow bracket TP+SL; EXT: limit+Day+extended, no brackets/trailing.
+5) **Surface actions**:
+   - For `active` items: propose a **Trade Preview** (DRY_RUN) with `risk.perTradePct=0.02`.
+   - For `monitor` items: keep on list; set price/indicator alerts (journal note).
+6) **Journal**:
+   - Append a session summary: counts {active, monitor}, top symbols, notable changes.
+
+## Add / Update / Remove
+- **Add:** when a symbol first matches a strategy minimum or passes Classifier gate.
+- **Update:** if status changes (monitor→active, active→exit); record cause (RVOL/PIR/level reclaim).
+- **Remove:** stale (TTL exceeded), thesis broken (range break against plan), earnings block inside 48h.
+
+## Prioritisation
+Rank by:
+1) **Classifier score**, then
+2) **Liquidity/Spread fitness**, then
+3) **Proximity to trigger** (e.g., distance to breakout level), then
+4) **Portfolio fit** (exposure by sector/name; correlation to holdings).
+
+## Example Entry
+```json
+{
+  "strategy": "breakout",
+  "symbol": "AAPL",
+  "reason": "RVOL 1.8, PIR 86, above SMA50; nearing range high 198.50",
+  "added_ts": "2025-09-21T18:30:00Z"
+}
+```
+
+## Hand‑offs
+- **From Watchlist → Simulation (DRY_RUN):**
+  - Build `trade_preview` with:
+    - `order.type="limit"`, `order.tif="day"`, `order.session="RTH|EXT"`,
+    - `exits.stop` per strategy (tightest of level vs ATR rule),
+    - `exits.target` measured move / prior high,
+    - `risk.perTradePct=0.02` (default), `rr` if requested.
+- **From Simulation → Live:**
+  - Only on explicit **CONFIRM: LIVE** and after re‑checking drift and gates.
+
+## Notes
+- If a symbol fails the gate, **do not trade**—leave on watchlist with a clear reason.
+- Re‑evaluate after material changes (RVOL spike, level reclaim, catalyst).


### PR DESCRIPTION
## Summary
- update alpha strategy reference to set a 2% default per-trade risk and note the default in implementation hints
- add a default of 2% to the trade_preview schema
- document a watchlist workflow aligned with the default risk setting

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d02548ec68832f810f9c85ed9e96e3