### PR TITLE
Add TTL metadata to preflight and trade preview schemas

### DIFF
--- a/docs/alpha_latest/preflight_check.schema.json
+++ b/docs/alpha_latest/preflight_check.schema.json
@@ -3,6 +3,43 @@
   "title": "PreflightCheck",
   "type": "object",
   "properties": {
+    "ttl": {
+      "type": "object",
+      "properties": {
+        "quote": {
+          "type": "object",
+          "properties": {
+            "asof": { "type": "string", "format": "date-time" },
+            "ttl_s": { "type": "integer", "default": 10 },
+            "ok": { "type": "boolean" }
+          },
+          "required": ["asof","ok"],
+          "additionalProperties": false
+        },
+        "balances": {
+          "type": "object",
+          "properties": {
+            "asof": { "type": "string", "format": "date-time" },
+            "ttl_s": { "type": "integer", "default": 10 },
+            "ok": { "type": "boolean" }
+          },
+          "required": ["asof","ok"],
+          "additionalProperties": false
+        },
+        "positions": {
+          "type": "object",
+          "properties": {
+            "asof": { "type": "string", "format": "date-time" },
+            "ttl_s": { "type": "integer", "default": 10 },
+            "ok": { "type": "boolean" }
+          },
+          "required": ["asof","ok"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["quote","balances","positions"],
+      "additionalProperties": false
+    },
     "balances": {
       "type": "object",
       "properties": {
@@ -42,6 +79,6 @@
       }
     }
   },
-  "required": ["balances","positions","market_session","violations"],
+  "required": ["ttl","balances","positions","market_session","violations"],
   "additionalProperties": false
 }

--- a/docs/alpha_latest/trade_preview.schema.json
+++ b/docs/alpha_latest/trade_preview.schema.json
@@ -43,8 +43,24 @@
       },
       "additionalProperties": false
     },
+    "data_freshness": {
+      "type": "object",
+      "properties": {
+        "quote_asof": { "type": "string", "format": "date-time" },
+        "quote_ttl_s": { "type": "integer", "default": 10 },
+        "quote_ttl_ok": { "type": "boolean" },
+        "balances_asof": { "type": "string", "format": "date-time" },
+        "balances_ttl_s": { "type": "integer", "default": 10 },
+        "balances_ttl_ok": { "type": "boolean" },
+        "positions_asof": { "type": "string", "format": "date-time" },
+        "positions_ttl_s": { "type": "integer", "default": 10 },
+        "positions_ttl_ok": { "type": "boolean" }
+      },
+      "required": ["quote_asof","quote_ttl_ok","balances_asof","balances_ttl_ok","positions_asof","positions_ttl_ok"],
+      "additionalProperties": false
+    },
     "assumptions": { "type": "array", "items": { "type": "string" } }
   },
-  "required": ["mode","action","symbol","qty","order"],
+  "required": ["mode","action","symbol","qty","order","data_freshness"],
   "additionalProperties": false
 }


### PR DESCRIPTION
## Summary
- extend the preflight check schema with ttl metadata for quotes, balances, and positions
- add data freshness ttl metadata to the trade preview schema and mark it required

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d039bca48c832fadd2dc7e4523d7a1