### PR TITLE
Add Create Order endpoint to OpenAPI spec

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -17,6 +17,26 @@ servers:
 security:
   - ApiKeyAuth: []
 paths:
+  /v2/orders:
+    post:
+      summary: Create Order
+      operationId: order_create
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateOrder'
+      responses:
+        '200':
+          description: Order accepted
+          content:
+            application/json:
+              schema: {}
+        '4XX':
+          description: Client error
+        '5XX':
+          description: Server error
   /v1/order/bracket:
     post:
       tags:
@@ -531,6 +551,57 @@ paths:
               schema: {}
 components:
   schemas:
+    CreateOrder:
+      type: object
+      additionalProperties: false
+      required:
+        - symbol
+        - side
+        - qty
+        - type
+        - time_in_force
+      properties:
+        symbol:
+          type: string
+        side:
+          type: string
+          enum: [buy, sell]
+        qty:
+          type: number
+          minimum: 1
+        type:
+          type: string
+          enum: [market, limit, stop, stop_limit]
+        time_in_force:
+          type: string
+          enum: [day, gtc]
+        limit_price:
+          type: number
+          nullable: true
+        stop_price:
+          type: number
+          nullable: true
+        order_class:
+          type: string
+          enum: [simple, bracket, oco, oto]
+          default: simple
+        take_profit:
+          type: object
+          additionalProperties: false
+          properties:
+            limit_price:
+              type: number
+        stop_loss:
+          type: object
+          additionalProperties: false
+          properties:
+            stop_price:
+              type: number
+            limit_price:
+              type: number
+        extended_hours:
+          type: boolean
+          default: false
     BracketOrderBody:
       properties:
         symbol:


### PR DESCRIPTION
## Summary
- add OpenAPI specification for the v2 create order endpoint
- define the CreateOrder schema with order parameters and nested take-profit/stop-loss objects

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d164bd6b84832fae18865769600e13