### PR TITLE
Add Create Order v2 endpoint to OpenAPI spec

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1095,6 +1095,38 @@
         }
       }
     },
+    "/v2/orders": {
+      "post": {
+        "summary": "Create Order",
+        "operationId": "order_create",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateOrder"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Order accepted",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "4XX": {
+            "description": "Client error"
+          },
+          "5XX": {
+            "description": "Server error"
+          }
+        }
+      }
+    },
     "/openapi.yaml": {
       "get": {
         "summary": "Spec",
@@ -1489,6 +1521,92 @@
           "side"
         ],
         "title": "TrailingOrderBody"
+      },
+      "CreateOrder": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "symbol",
+          "side",
+          "qty",
+          "type",
+          "time_in_force"
+        ],
+        "properties": {
+          "symbol": {
+            "type": "string"
+          },
+          "side": {
+            "type": "string",
+            "enum": [
+              "buy",
+              "sell"
+            ]
+          },
+          "qty": {
+            "type": "number",
+            "minimum": 1
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "market",
+              "limit",
+              "stop",
+              "stop_limit"
+            ]
+          },
+          "time_in_force": {
+            "type": "string",
+            "enum": [
+              "day",
+              "gtc"
+            ]
+          },
+          "limit_price": {
+            "type": "number",
+            "nullable": true
+          },
+          "stop_price": {
+            "type": "number",
+            "nullable": true
+          },
+          "order_class": {
+            "type": "string",
+            "enum": [
+              "simple",
+              "bracket",
+              "oco",
+              "oto"
+            ],
+            "default": "simple"
+          },
+          "take_profit": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "limit_price": {
+                "type": "number"
+              }
+            }
+          },
+          "stop_loss": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "stop_price": {
+                "type": "number"
+              },
+              "limit_price": {
+                "type": "number"
+              }
+            }
+          },
+          "extended_hours": {
+            "type": "boolean",
+            "default": false
+          }
+        }
       },
       "ValidationError": {
         "properties": {


### PR DESCRIPTION
## Summary
- add the POST /v2/orders endpoint to the OpenAPI specification
- define the CreateOrder schema for the endpoint request payload

## Testing
- python -m json.tool openapi.json > /tmp/openapi_fmt.json

------
https://chatgpt.com/codex/tasks/task_e_68d1674d9584832f9b5b6a23a304068e