### PR TITLE
Update order wildcard routing metadata

### DIFF
--- a/docs/alpha_latest/router_map.json
+++ b/docs/alpha_latest/router_map.json
@@ -38,6 +38,10 @@
     "risk.limit": "internal.risk",
     "compliance": "internal.compliance"
   },
+  "order.*": {
+    "route": "alpaca",
+    "operationId": "order_create"
+  },
   "rules": [
     { "pattern": "^quote\\.", "route": "finnhub", "priority": 100 },
     { "pattern": "^order\\.", "route": "alpaca", "priority": 100 },


### PR DESCRIPTION
## Summary
- document that wildcard order commands route to the Alpaca target
- include the associated OpenAPI operation id for order creation in the router map

## Testing
- python -m json.tool docs/alpha_latest/router_map.json

------
https://chatgpt.com/codex/tasks/task_e_68d182d95904832fa816998712b09e31