### PR TITLE
Add Alpaca API security schemes to OpenAPI spec

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1098,7 +1098,15 @@
     "/v2/orders": {
       "post": {
         "summary": "Create Order",
-        "operationId": "order_create",
+        "operationId": "order.create",
+        "security": [
+          {
+            "alpacaKey": []
+          },
+          {
+            "alpacaSecret": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -1145,6 +1153,18 @@
     }
   },
   "components": {
+    "securitySchemes": {
+      "alpacaKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "APCA-API-KEY-ID"
+      },
+      "alpacaSecret": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "APCA-API-SECRET-KEY"
+      }
+    },
     "schemas": {
       "BracketOrderBody": {
         "properties": {


### PR DESCRIPTION
## Summary
- add alpaca api key and secret security schemes to the OpenAPI components section
- require those credentials and update the operationId for the v2 create order endpoint

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d19c4b6ee0832f98f27487a34a02f2