### PR TITLE
Update OpenAPI order schema for Alpaca orders

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1101,10 +1101,7 @@
         "operationId": "order.create",
         "security": [
           {
-            "alpacaKey": []
-          },
-          {
-            "alpacaSecret": []
+            "ApiKeyAuth": []
           }
         ],
         "requestBody": {
@@ -1126,13 +1123,10 @@
               }
             }
           },
-          "401": {
-            "description": "Unauthorized (missing/invalid keys)"
+          "4XX": {
+            "description": "Client error"
           },
-          "422": {
-            "description": "Validation Error"
-          },
-          "500": {
+          "5XX": {
             "description": "Server error"
           }
         }
@@ -1621,7 +1615,7 @@
             ]
           },
           "qty": {
-            "type": "integer",
+            "type": "number",
             "minimum": 1
           },
           "type": {
@@ -1641,15 +1635,23 @@
             ]
           },
           "limit_price": {
-            "type": [
-              "number",
-              "null"
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
             ]
           },
           "stop_price": {
-            "type": [
-              "number",
-              "null"
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
             ]
           },
           "order_class": {


### PR DESCRIPTION
## Summary
- switch the POST /v2/orders security scheme to ApiKeyAuth and consolidate error responses into 4XX/5XX ranges
- relax CreateOrder.qty to use a numeric type and express nullable limit/stop prices with anyOf clauses

## Testing
- not run (schema documentation change)


------
https://chatgpt.com/codex/tasks/task_e_68d1aed658c0832f807d17e573634ba8