### PR TITLE
Add trailing stop fields to CreateOrder schema

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1624,7 +1624,8 @@
               "market",
               "limit",
               "stop",
-              "stop_limit"
+              "stop_limit",
+              "trailing_stop"
             ]
           },
           "time_in_force": {
@@ -1645,6 +1646,26 @@
             ]
           },
           "stop_price": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "trail_price": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "trail_percent": {
             "anyOf": [
               {
                 "type": "number"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -571,7 +571,7 @@ components:
           minimum: 1
         type:
           type: string
-          enum: [market, limit, stop, stop_limit]
+          enum: [market, limit, stop, stop_limit, trailing_stop]
         time_in_force:
           type: string
           enum: [day, gtc]
@@ -579,6 +579,12 @@ components:
           type: number
           nullable: true
         stop_price:
+          type: number
+          nullable: true
+        trail_price:
+          type: number
+          nullable: true
+        trail_percent:
           type: number
           nullable: true
         order_class:


### PR DESCRIPTION
## Summary
- add trailing_stop order type to the CreateOrder schema
- document optional trail_price and trail_percent fields used by trailing stop orders in both JSON and YAML specs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1b21f4b28832f8a6127ea8ec90b4c