### PR TITLE
Enforce trailing stop constraints and global API key security

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1656,23 +1656,15 @@
             ]
           },
           "trail_price": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
+            "type": [
+              "number",
+              "null"
             ]
           },
           "trail_percent": {
-            "anyOf": [
-              {
-                "type": "number"
-              },
-              {
-                "type": "null"
-              }
+            "type": [
+              "number",
+              "null"
             ]
           },
           "order_class": {
@@ -1716,7 +1708,40 @@
               "null"
             ]
           }
-        }
+        },
+        "allOf": [
+          {
+            "oneOf": [
+              {
+                "required": [
+                  "trail_price"
+                ]
+              },
+              {
+                "required": [
+                  "trail_percent"
+                ]
+              }
+            ],
+            "if": {
+              "properties": {
+                "type": {
+                  "const": "trailing_stop"
+                }
+              }
+            },
+            "then": {
+              "not": {
+                "required": [
+                  "limit_price",
+                  "stop_price",
+                  "take_profit",
+                  "stop_loss"
+                ]
+              }
+            }
+          }
+        ]
       },
       "ValidationError": {
         "properties": {
@@ -1784,6 +1809,11 @@
   "servers": [
     {
       "url": "https://alpaca-py-production.up.railway.app"
+    }
+  ],
+  "security": [
+    {
+      "ApiKeyAuth": []
     }
   ]
 }


### PR DESCRIPTION
## Summary
- define global ApiKeyAuth security requirements in the OpenAPI document
- tighten CreateOrder schema so trailing_stop orders require a trail price or percent and omit conflicting price fields

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1b734edb8832faa18dba1069c7c8f