### PR TITLE
Add canonical operation metadata for order creation

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1098,7 +1098,8 @@
     "/v2/orders": {
       "post": {
         "summary": "Create Order",
-        "operationId": "order.create",
+        "operationId": "order_create",
+        "x-canonical-operation": "order.create",
         "security": [
           {
             "ApiKeyAuth": []

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -20,7 +20,8 @@ paths:
   /v2/orders:
     post:
       summary: Create order (Alpaca REST)
-      operationId: order.create
+      operationId: order_create
+      x-canonical-operation: order.create
       security:
         - ApiKeyAuth: []
       requestBody:


### PR DESCRIPTION
## Summary
- update the `/v2/orders` POST operationId to the new `order_create` name
- add the `x-canonical-operation` extension mapping back to the legacy `order.create`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d1cc837e90832f93c8cae106f68c41