### PR TITLE
Adjust OpenAPI schema comments and nullability

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,12 +1,11 @@
 openapi: 3.1.0
-# removed unsupported jsonSchemaDialect (not allowed by Actions importer)
+
 info:
   title: Alpaca Wrapper
   version: 1.0.1
 
 servers:
   - url: https://alpaca-py-production.up.railway.app
-    # removed description to avoid extra keys
 
 # Require the ApiKeyAuth security scheme by default.  Operations that should
 # remain publicly accessible explicitly override this with `security: []`.
@@ -17,7 +16,7 @@ paths:
     post:
       summary: Create order (Alpaca REST)
       operationId: order_create
-      # removed vendor-specific x-canonical-operation (not understood by importer)
+      # (no vendor extension)
       security:
         - ApiKeyAuth: []
       requestBody:
@@ -633,9 +632,13 @@ components:
               - required: [trail_percent]
             properties:
               limit_price:
-                nullable: true
+                anyOf:
+                  - type: number
+                  - type: 'null'
               stop_price:
-                nullable: true
+                anyOf:
+                  - type: number
+                  - type: 'null'
         - if:
             properties:
               order_class:


### PR DESCRIPTION
## Summary
- remove obsolete comments from the OpenAPI document header
- clarify the comment for the `/v2/orders` operation vendor extension placeholder
- express `limit_price` and `stop_price` nullable values using JSON Schema `anyOf`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1f3863eec832f9fb05865583e8a4f