### PR TITLE
Clean OpenAPI specs for importer compatibility

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1099,7 +1099,6 @@
       "post": {
         "summary": "Create Order",
         "operationId": "order_create",
-        "x-canonical-operation": "order.create",
         "security": [
           {
             "ApiKeyAuth": []
@@ -1130,7 +1129,25 @@
           "5XX": {
             "description": "Server error"
           }
-        }
+        },
+        "parameters": [
+          {
+            "name": "x-api-key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ]
       }
     },
     "/v2/account": {
@@ -1202,10 +1219,63 @@
           }
         }
       }
+    },
+    "/v2/orders/{order_id}": {
+      "delete": {
+        "summary": "Cancel order by ID",
+        "operationId": "cancelOrderById_v2",
+        "parameters": [
+          {
+            "name": "order_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Order Id"
+            }
+          },
+          {
+            "name": "x-api-key",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Api-Key"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Order cancelled"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
     "securitySchemes": {
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "x-api-key"
+      },
       "alpacaKey": {
         "type": "apiKey",
         "in": "header",
@@ -1797,13 +1867,6 @@
           "symbols"
         ],
         "title": "WatchlistIn"
-      }
-    },
-    "securitySchemes": {
-      "ApiKeyAuth": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "x-api-key"
       }
     }
   },

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7,16 +7,22 @@ info:
 servers:
   - url: https://alpaca-py-production.up.railway.app
 
-# Require the ApiKeyAuth security scheme by default.  Operations that should
-# remain publicly accessible explicitly override this with `security: []`.
 security:
   - ApiKeyAuth: []
 paths:
   /v2/orders:
     post:
-      summary: Create order (Alpaca REST)
+      summary: Create Order
       operationId: order_create
-      # (no vendor extension)
+      parameters:
+      - name: x-api-key
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Api-Key
       security:
         - ApiKeyAuth: []
       requestBody:
@@ -199,9 +205,23 @@ paths:
         schema:
           type: string
           title: Order Id
+      - name: x-api-key
+        in: header
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Api-Key
       responses:
         '204':
           description: Order cancelled
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /v1/account:
     get:
       summary: Get Account


### PR DESCRIPTION
## Summary
- align the `/v2/orders` OpenAPI definitions with the importer by normalizing metadata and documenting the optional `x-api-key` header
- describe the `/v2/orders/{order_id}` cancellation endpoint with its header parameter and validation error response
- expose the `ApiKeyAuth` scheme in the JSON spec alongside the existing Alpaca key headers

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1fab4ccd8832f8c3abf52b8aa1b8b