### PR TITLE
Update Trading API secret header definitions

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Alpaca Trading API (Live)
-  version: "1.0.1"
+  version: 1.0.2
 servers:
   - url: https://api.alpaca.markets
 paths:
@@ -11,7 +11,11 @@ paths:
       operationId: ordersCreate
       security: [{ ApiKeyAuth: [] }]
       parameters:
-        - $ref: "#/components/parameters/AlpacaSecret"
+        - name: APCA-API-SECRET-KEY
+          in: header
+          required: true
+          description: Alpaca API secret header required by Trading API
+          schema: { type: string }
       requestBody:
         required: true
         content:
@@ -24,7 +28,10 @@ paths:
       operationId: ordersList
       security: [{ ApiKeyAuth: [] }]
       parameters:
-        - $ref: "#/components/parameters/AlpacaSecret"
+        - name: APCA-API-SECRET-KEY
+          in: header
+          required: true
+          schema: { type: string }
         - name: status
           in: query
           required: false
@@ -37,7 +44,10 @@ paths:
       operationId: ordersGetById
       security: [{ ApiKeyAuth: [] }]
       parameters:
-        - $ref: "#/components/parameters/AlpacaSecret"
+        - name: APCA-API-SECRET-KEY
+          in: header
+          required: true
+          schema: { type: string }
         - { name: order_id, in: path, required: true, schema: { type: string } }
       responses:
         "200": { description: Order detail }
@@ -46,7 +56,10 @@ paths:
       operationId: ordersCancelById
       security: [{ ApiKeyAuth: [] }]
       parameters:
-        - $ref: "#/components/parameters/AlpacaSecret"
+        - name: APCA-API-SECRET-KEY
+          in: header
+          required: true
+          schema: { type: string }
         - { name: order_id, in: path, required: true, schema: { type: string } }
       responses:
         "204": { description: Order cancelled }
@@ -56,7 +69,10 @@ paths:
       operationId: accountGet
       security: [{ ApiKeyAuth: [] }]
       parameters:
-        - $ref: "#/components/parameters/AlpacaSecret"
+        - name: APCA-API-SECRET-KEY
+          in: header
+          required: true
+          schema: { type: string }
       responses:
         "200": { description: Account info }
   /v2/positions:
@@ -65,7 +81,10 @@ paths:
       operationId: positionsList
       security: [{ ApiKeyAuth: [] }]
       parameters:
-        - $ref: "#/components/parameters/AlpacaSecret"
+        - name: APCA-API-SECRET-KEY
+          in: header
+          required: true
+          schema: { type: string }
       responses:
         "200": { description: Positions list }
     delete:
@@ -73,7 +92,10 @@ paths:
       operationId: positionsCloseAll
       security: [{ ApiKeyAuth: [] }]
       parameters:
-        - $ref: "#/components/parameters/AlpacaSecret"
+        - name: APCA-API-SECRET-KEY
+          in: header
+          required: true
+          schema: { type: string }
         - { name: cancel_orders, in: query, required: false, schema: { type: boolean, default: false } }
       responses:
         "200": { description: Positions closed }
@@ -83,7 +105,10 @@ paths:
       operationId: positionsGet
       security: [{ ApiKeyAuth: [] }]
       parameters:
-        - $ref: "#/components/parameters/AlpacaSecret"
+        - name: APCA-API-SECRET-KEY
+          in: header
+          required: true
+          schema: { type: string }
         - { name: symbol, in: path, required: true, schema: { type: string } }
       responses:
         "200": { description: Position detail }
@@ -92,7 +117,10 @@ paths:
       operationId: positionsClose
       security: [{ ApiKeyAuth: [] }]
       parameters:
-        - $ref: "#/components/parameters/AlpacaSecret"
+        - name: APCA-API-SECRET-KEY
+          in: header
+          required: true
+          schema: { type: string }
         - { name: symbol, in: path, required: true, schema: { type: string } }
         - { name: cancel_orders, in: query, required: false, schema: { type: boolean, default: false } }
       responses:
@@ -103,7 +131,10 @@ paths:
       operationId: watchlistsList
       security: [{ ApiKeyAuth: [] }]
       parameters:
-        - $ref: "#/components/parameters/AlpacaSecret"
+        - name: APCA-API-SECRET-KEY
+          in: header
+          required: true
+          schema: { type: string }
       responses:
         "200": { description: Watchlists list }
     post:
@@ -111,7 +142,10 @@ paths:
       operationId: watchlistsCreate
       security: [{ ApiKeyAuth: [] }]
       parameters:
-        - $ref: "#/components/parameters/AlpacaSecret"
+        - name: APCA-API-SECRET-KEY
+          in: header
+          required: true
+          schema: { type: string }
       requestBody:
         required: true
         content:
@@ -125,7 +159,10 @@ paths:
       operationId: watchlistsGet
       security: [{ ApiKeyAuth: [] }]
       parameters:
-        - $ref: "#/components/parameters/AlpacaSecret"
+        - name: APCA-API-SECRET-KEY
+          in: header
+          required: true
+          schema: { type: string }
         - { name: watchlist_id, in: path, required: true, schema: { type: string } }
       responses:
         "200": { description: Watchlist detail }
@@ -134,7 +171,10 @@ paths:
       operationId: watchlistsUpdate
       security: [{ ApiKeyAuth: [] }]
       parameters:
-        - $ref: "#/components/parameters/AlpacaSecret"
+        - name: APCA-API-SECRET-KEY
+          in: header
+          required: true
+          schema: { type: string }
         - { name: watchlist_id, in: path, required: true, schema: { type: string } }
       requestBody:
         required: true
@@ -148,7 +188,10 @@ paths:
       operationId: watchlistsDelete
       security: [{ ApiKeyAuth: [] }]
       parameters:
-        - $ref: "#/components/parameters/AlpacaSecret"
+        - name: APCA-API-SECRET-KEY
+          in: header
+          required: true
+          schema: { type: string }
         - { name: watchlist_id, in: path, required: true, schema: { type: string } }
       responses:
         "200": { description: Watchlist deleted }
@@ -158,13 +201,6 @@ components:
       type: apiKey
       in: header
       name: APCA-API-KEY-ID
-  parameters:
-    AlpacaSecret:
-      name: APCA-API-SECRET-KEY
-      in: header
-      required: true
-      description: Alpaca API secret header required by Trading API
-      schema: { type: string }
   schemas:
     OrderIn:
       type: object


### PR DESCRIPTION
## Summary
- bump the OpenAPI version to 1.0.2 and inline the APCA-API-SECRET-KEY header requirement on trading endpoints
- remove the shared AlpacaSecret parameter component now that the header is defined inline

## Testing
- not run (spec changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d2cb63b510832fbc1ffdfdf5669295