### PR TITLE
Update wrapper OpenAPI metadata

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
-  title: Alpaca Trading API (Live via Railway Proxy)
-  version: 1.1.0
+  title: Alpaca Trading API (Live via Wrapper)
+  version: 1.0.3
 servers:
   # Use your deployed proxy so clients only need ONE API key header.
   - url: https://alpaca-py-production.up.railway.app
@@ -191,7 +191,7 @@ components:
     ApiKeyAuth:
       type: apiKey
       in: header
-      name: X-API-Key
+      name: x-api-key
   schemas:
     OrderIn:
       type: object


### PR DESCRIPTION
## Summary
- update the OpenAPI document to reference the wrapper deployment and new API key header
- align the published version metadata with the wrapper settings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2dbc6b0d0832f895f4f95d4c44041