### PR TITLE
Add async Alpaca REST proxy endpoints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ pandas = ">=1.5.3"
 msgpack = "^1.0.3"
 websockets = ">=10.4"
 sseclient-py = "^1.7.2"
+aiohttp = "^3.9.3"
 
 
 [tool.poetry.dev-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ fastapi
 uvicorn[standard]
 alpaca-py
 pandas
+aiohttp
 fastapi
 uvicorn[standard]
 alpaca-py


### PR DESCRIPTION
## Summary
- add aiohttp-based proxy routes for Alpaca v2 account, order, and position APIs
- enforce optional gateway key header and share upstream Alpaca credentials from environment
- declare aiohttp dependency for runtime use

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d2dd043d68832fa4e01bdafb2ff91e