### PR TITLE
Add knowledge base documentation for custom GPT

### DIFF
--- a/docs/knowledge/KNOWLEDGE_INDEX.md
+++ b/docs/knowledge/KNOWLEDGE_INDEX.md
@@ -1,0 +1,34 @@
+# Alpha Knowledge Pack v1 — 2025‑09‑28
+Scope: supporting docs for the 6 actions. Source of truth = Actions OpenAPI + Router OAS + these files. Archive all old docs.
+
+## Folders
+- adapters/: classifier + FinRL + journals mappings
+- policies/: routing, risk, session, idempotency, errors
+- workflows/: fast_lane, watchlist, memory
+- specs/: endpoint summaries (not full OpenAPI)
+- tests/: golden prompts + pass criteria
+- scripts/: PowerShell 7 smokes
+- snippets/: reusable response text
+
+## Rules
+- Do not copy rules from Instructions; reference them.
+- Charts basis: CP‑CAP‑1, CP‑FAST‑1, CP‑ACCT‑1, CP‑RISK‑1, CP‑IDEMP‑1, CP‑ENV‑1, CP‑ERR‑1, CP‑CLF‑1, CP‑CLF‑ADAPT‑1, CP‑WL‑1, CP‑JRN‑1, CP‑MEM‑1, CP‑RL‑CORE‑1, CP‑RL‑TRAIN‑1, CP‑RL‑JOBS‑1, CP‑TI‑ALIGN‑1.
+
+## Contents
+- adapters/classifier_adapter.md
+- adapters/finrl_adapter.md
+- adapters/journal_mapping.md
+- policies/routing_map.md
+- policies/risk_policy.md
+- policies/idempotency.md
+- policies/error_policy.md
+- workflows/fast_lane.md
+- workflows/watchlist.md
+- workflows/memory.md
+- specs/alpaca_summary.md
+- specs/finrl_summary.md
+- specs/journals_summary.md
+- specs/classifier_summary.md
+- specs/finnhub_summary.md
+- tests/golden_prompts.md
+- scripts/ps7_smoke.ps1

--- a/docs/knowledge/README.md
+++ b/docs/knowledge/README.md
@@ -1,0 +1,7 @@
+# docs/knowledge
+
+Authoritative supporting material for the Custom GPT.
+Keep in sync with Instructions and the six Actions OpenAPI specs.
+Archive old project knowledge; do not rely on legacy files.
+
+See KNOWLEDGE_INDEX.md for the map.

--- a/docs/knowledge/adapters/classifier_adapter.md
+++ b/docs/knowledge/adapters/classifier_adapter.md
@@ -1,0 +1,23 @@
+# Classifier adapter
+
+## API
+- POST /classify {symbols[], rvolMode:'20bar'} → ClassifyItem[].
+
+## Mapping to internal AlphaClassifierOutput
+- features.trend = close / sma50 − 1
+- features.rvol = rvol15
+- features.pir = pir_pct / 100
+- features.atr = atr
+- features.confirm = confirm
+- label = Sell if candidates contains “Breakdown Short”; else Buy if contains “Breakout Long” or “Pullback Long”; else Neutral
+- score = clamp(0,1, 0.5 + 0.6*trend + 0.2*(rvol − 1) + 0.1*(1 − abs(pir_pct − 50)/50))
+- If label=Buy and score ≥ 0.85 → label=StrongBuy
+
+## Gate
+- Proceed only if label ∈ {StrongBuy, Buy} AND score ≥ 0.70.
+
+## Errors
+- 401/429/5xx → return Neutral, score=0.50; add error.kind and remedy; watchlist as needed.
+
+## Batching
+- Chunk to ≤50 per call.

--- a/docs/knowledge/adapters/finrl_adapter.md
+++ b/docs/knowledge/adapters/finrl_adapter.md
@@ -1,0 +1,21 @@
+# FinRL adapter
+
+## Endpoints (OpenAPI v1.3.11 only)
+- POST /train, GET /predict, POST /backtest, GET /status/{job_id}, GET /signal, GET /risk, POST /run_all, GET /healthz. /order exists but is a reject stub.
+
+## Usage
+- Default: remote predict/backtest for fast metrics; local train only on explicit request; consent line required.
+- Jobs: /train and /backtest return job_id; do not block; check /status/{job_id} only on request.
+
+## Evidence mapping
+- finrl_signal: {symbol, version, side, signal, confidence?}
+- finrl_metrics: {total_reward, sharpe, win_rate, trade_steps, params?}
+
+## Presentation
+- Human line: “RL: {side, conf} · Sharpe {x} · DD {y}”.
+
+## Watchlist EV
+- Weight RL with Classifier, Liquidity, Trigger, Portfolio, Exposure (weights live in tests or code).
+
+## Limits
+- RL never overrides TTL, sizing, session, or risk gates.

--- a/docs/knowledge/adapters/journal_mapping.md
+++ b/docs/knowledge/adapters/journal_mapping.md
@@ -1,0 +1,19 @@
+# Journal mapping
+
+## Router → Journals (POST /journal)
+- ts→entry_time
+- symbol→symbol
+- avg_price→entry_price
+- sl→stop_price
+- tp→tp_price
+- side: buy→long, sell→short
+- notes→notes
+
+## Tags (tags.*)
+- mode, route, action, qty, client_order_id, order_id, order_class, type, time_in_force, session, quote_asof, equity, buying_power, request_id.
+
+## Updates
+- On fills/exits PATCH /journal/{id} with exit_time, exit_price, outcome.
+
+## Bulk
+- Use {items:[JournalIn,...]} for /journal/bulk.

--- a/docs/knowledge/policies/error_policy.md
+++ b/docs/knowledge/policies/error_policy.md
@@ -1,0 +1,14 @@
+# Error policy
+
+## Kinds
+- AUTH, VALIDATION, SESSION, RATE_LIMIT, RETRYABLE, UNSUPPORTED
+
+## Retry rules
+- 5xx: retry once with 200–500 ms jitter.
+- 429: honor Retry‑After up to 5 s, then single retry.
+
+## Circuit breaker
+- After two consecutive failures on the same symbol: 30 s open; degrade to watchlist entry with appropriate reason.
+
+## Failure payloads
+- Always include `error.kind`, `remedy`, `next_step`.

--- a/docs/knowledge/policies/idempotency.md
+++ b/docs/knowledge/policies/idempotency.md
@@ -1,0 +1,5 @@
+# Idempotency
+
+- Require client_order_id on create. If missing: alpha-YYYYMMDDHHmmss-rand6.
+- Pre‑create check: list orders and return existing by client_order_id if present (no duplicate submit).
+- Journal dedupe: exactly one Journal per client_order_id.

--- a/docs/knowledge/policies/risk_policy.md
+++ b/docs/knowledge/policies/risk_policy.md
@@ -1,0 +1,19 @@
+# Risk policy
+
+## Sizing
+- qty = floor((equity * risk_pct) / abs(entry − stop)); risk_pct=0.02 default.
+
+## Exposure + Halts
+- Per‑name exposure cap: (position_value + order_value) ≤ 0.20 * equity.
+- Daily loss halt: realized_pnl_day > −0.05 * equity_day_start required to place new entries.
+
+## Sessions
+- RTH: allow market/limit/stop/stop_limit; brackets permitted.
+- EXT: enforce limit + day + extended=true; no bracket; no trailing entry.
+
+## Freshness + Slippage
+- TTL: quote/balances/positions must be fresh (≤10s). If stale, refresh Preflight.
+- Slippage guard: |limit − last| / last ≤ 0.005.
+
+## Earnings gate
+- No new entries in the no‑trade window unless user explicitly approves where policy allows. Prefer watchlist.

--- a/docs/knowledge/policies/routing_map.md
+++ b/docs/knowledge/policies/routing_map.md
@@ -1,0 +1,23 @@
+# Routing map
+
+## Aliases → Target
+- ord.new, order.create, buy.*, sell.* → alpaca
+- ord.cancel, order.cancel → alpaca
+- acct.snap, account.get → alpaca
+- pos.list, position.* → alpaca
+- wl.*, watchlist.* → alpaca
+- quote.get, candles.get, fundamentals.get → finnhub
+- cls.run, classify.list → classifier
+- rl.train, rl.predict, rl.backtest, rl.status, rl.signal, rl.risk, rl.run_all → finrl
+- journal.create, journal.bulk, journal.update, params.save, params.load → journal
+- schema.route, schema.preview, schema.validate, schema.journal, schema.fast → router
+
+## Router artifact order
+- Always emit (echo‑only): RouteDecision → TradePreview → OrderValidation → (submit) → JournalEntry
+- Fast lane emits bundle: FastLaneResult {route_decision, trade_preview, order_validation, submitted_order?, journal_entry, elapsed_ms}
+
+## Secrets
+- Never send secrets in payloads or notes.
+
+## Notes
+- Router is schema‑carrier only.

--- a/docs/knowledge/scripts/ps7_smoke.ps1
+++ b/docs/knowledge/scripts/ps7_smoke.ps1
@@ -1,0 +1,20 @@
+# PowerShell 7 smoke tests (Paper)
+
+# 1) Account snapshot
+Invoke-RestMethod "$env:ALPACA_API_BASE_URL/v2/account" -Headers @{ 'x-api-key' = $env:ALPACA_API_KEY }
+
+# 2) Create Paper order (client-side idempotency)
+$cid = "alpha-$(Get-Date -UFormat %Y%m%d%H%M%S)-$([System.Guid]::NewGuid().ToString('N').Substring(0,6))"
+$body = @{
+  symbol = "AAPL"
+  side = "buy"
+  type = "limit"
+  time_in_force = "day"
+  qty = 1
+  limit_price = 10
+  client_order_id = $cid
+} | ConvertTo-Json
+Invoke-RestMethod "$env:ALPACA_API_BASE_URL/v2/orders" -Method Post -ContentType "application/json" -Body $body -Headers @{ 'x-api-key' = $env:ALPACA_API_KEY }
+
+# 3) List orders; confirm idempotency by client_order_id
+Invoke-RestMethod "$env:ALPACA_API_BASE_URL/v2/orders" -Headers @{ 'x-api-key' = $env:ALPACA_API_KEY }

--- a/docs/knowledge/snippets/tone.md
+++ b/docs/knowledge/snippets/tone.md
@@ -1,0 +1,5 @@
+# Snippets: tone and guidance
+
+Next moves: “Generate trade preview”, “Submit via Fast lane”, “Add to watchlist”
+Pro move: “Stage exits at RTH using bracket”
+Blocked template: “Blocked by {rule}. Simplest fix: {action}”

--- a/docs/knowledge/specs/alpaca_summary.md
+++ b/docs/knowledge/specs/alpaca_summary.md
@@ -1,0 +1,19 @@
+# Alpaca‑py summary
+
+## Auth
+- Header `x-api-key`
+
+## Core
+- POST /v2/orders (create; require client_order_id in caller)
+- GET /v2/orders (list), GET /v2/orders/{order_id}, DELETE /v2/orders/{order_id}
+- GET /v2/account
+- GET /v2/positions, DELETE /v2/positions (close all), GET/DELETE /v2/positions/{symbol}
+- Watchlists: GET/POST /v2/watchlists, GET/PUT/DELETE /v2/watchlists/{id}
+
+## Policy overlay
+- Allowed types: market, limit, stop, stop_limit
+- TIF: day, gtc
+- EXT: limit + day + extended=true; no bracket/trailing entries
+
+## Idempotency
+- Deduplicate by client_order_id client‑side.

--- a/docs/knowledge/specs/classifier_summary.md
+++ b/docs/knowledge/specs/classifier_summary.md
@@ -1,0 +1,13 @@
+# Alpha Classifier summary
+
+## Auth
+- Header `X-API-Key`
+
+## Endpoints
+- /healthz (GET), /classify (POST)
+
+## Limits
+- symbols 1..50; rvolMode default '20bar'
+
+## Output
+- ClassifyItem {symbol, close, sma50, atr, pir_pct, rvol15, candidates, confirm}

--- a/docs/knowledge/specs/finnhub_summary.md
+++ b/docs/knowledge/specs/finnhub_summary.md
@@ -1,0 +1,9 @@
+# Finnhub summary
+
+## Auth
+- Per your spec.
+
+## Must‑haves
+- Quote: last, asof, dp (percent). dp is already percent; do not divide by 100.
+- Candles: daily for RD/R5D; intraday for timing.
+- TTL: quote fresh ≤10s or block.

--- a/docs/knowledge/specs/finrl_summary.md
+++ b/docs/knowledge/specs/finrl_summary.md
@@ -1,0 +1,10 @@
+# FinRL summary
+
+## Auth
+- Header `X-API-Key`
+
+## Endpoints
+- /train, /predict, /backtest, /status/{job_id}, /signal, /risk, /run_all, /healthz
+
+## Notes
+- Mode via env; /order is reject stub; do not use for trading.

--- a/docs/knowledge/specs/journals_summary.md
+++ b/docs/knowledge/specs/journals_summary.md
@@ -1,0 +1,11 @@
+# Journals summary
+
+## Auth
+- Header `X-API-Key`
+
+## Endpoints
+- /health, /journal (GET/POST), /journal/bulk (POST), /journal/{id} (GET/PATCH/DELETE), /stats (GET), /params (POST), /params/latest (GET)
+
+## Shapes
+- JournalIn requires symbol; PATCH uses JournalIn; include symbol.
+- Params: {version, source?, blob{…}}

--- a/docs/knowledge/tests/golden_prompts.md
+++ b/docs/knowledge/tests/golden_prompts.md
@@ -1,0 +1,24 @@
+# Golden prompts (deterministic)
+
+Use Paper. Expect specific Router echoes or FastLaneResult bundles.
+
+1) Fast lane RTH limit: AAPL buy; fresh TTL; expect submitted_order!=null; journal created.
+2) EXT bracket reject: user requests bracket in EXT; expect validation.ok=false; reason includes EXT rule; next moves suggest RTH bracket.
+3) Quote TTL stale: expect prompt to refresh Preflight; no order.
+4) Earnings gate block: symbol inside window; expect watchlist add with reason=EarningsWindow.
+5) Per‑name exposure cap breach: expect validation false; reason ExposureLimit; no submit.
+6) Daily loss halt: block new entries; reason includes threshold.
+7) Slippage guard breach: limit too far; validation false.
+8) Idempotent retry: same client_order_id; second create returns existing.
+9) Batch 20 symbols: groups emitted; watchlist auto‑adds for near‑misses.
+10) Journaling on submit: verify one journal with mapped fields.
+11) Journals PATCH: exit update writes exit_time/exit_price/outcome.
+12) Memory sync: start chat, memory missing → load; annotate “Memory: missing”.
+13) FinRL predict: include RL summary line; no blocking if RL unavailable.
+14) FinRL train async: returns job_id; no blocking; status only on request.
+15) Classifier error 429: degrade; Neutral score; watchlist.
+16) EXT limit policy enforced via OrderValidation.
+17) RTH default template applied when user omits TIF/type.
+18) Watchlist “Rescore now” surfaced in batch.
+19) Fast lane dry_run:true returns bundle w/o submitted_order.
+20) Telemetry: elapsed_ms present with integer values.

--- a/docs/knowledge/workflows/fast_lane.md
+++ b/docs/knowledge/workflows/fast_lane.md
@@ -1,0 +1,19 @@
+# Fast lane workflow
+
+## Trigger
+- “Confirm and submit”
+
+## Atomic steps
+1) Preflight (freshness ≤10s) → compute size in TradePreview.
+2) Validate order intent (EXT policy, exposure, halt, slippage).
+3) Submit to Alpaca; enforce idempotency.
+4) Auto‑journal (LIVE only).
+
+## Output
+- FastLaneResult {route_decision, trade_preview, order_validation, submitted_order?, journal_entry, elapsed_ms}
+
+## Flags
+- dry_run:true executes steps 1–2 only, returns bundle with submitted_order=null.
+
+## Notes
+- No background work; synchronous single action.

--- a/docs/knowledge/workflows/memory.md
+++ b/docs/knowledge/workflows/memory.md
@@ -1,0 +1,15 @@
+# Memory workflow (Journals)
+
+## Store
+- POST /params {version:'latest', source:'alpha-memory', blob{account, positions, watchlist, last_orders, risk_config, strategy_state}}.
+
+## Load
+- GET /params/latest?source=alpha-memory&version=latest.
+
+## Policy
+- Sync at session start; precedence = live Preflight > memory; update memory when diverging.
+- Memory older than 30 days ⇒ stale; prompt refresh.
+- No secrets in blobs.
+
+## UI
+- Annotate responses: “Memory: loaded|missing|stale (as of <ts>)”.

--- a/docs/knowledge/workflows/watchlist.md
+++ b/docs/knowledge/workflows/watchlist.md
@@ -1,0 +1,16 @@
+# Watchlist workflow (batch)
+
+## Batch mode
+- Inputs: 15–50 symbols. Classify all; run light RL on all.
+
+## Groups
+- Actionable now | Watchlist added | Discarded.
+
+## Auto‑add reasons
+- ClassifierGateFail, EarningsWindow, SessionClosed, Halted, StrategyNearMiss, ExposureLimit.
+
+## Record
+- WatchlistEntry {strategy, symbol, reason, added_ts}; journal each add.
+
+## TTL
+- Do not auto‑watchlist on transient quote TTL failures; refresh first.


### PR DESCRIPTION
## Summary
- add a knowledge pack index and README for the updated custom GPT documentation
- document adapters, policies, workflows, specs, tests, scripts, and snippets required by the six actions

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d99402772c832f948f3743ed49ce9e