### PR TITLE
Document TI strategy cards source and remove tone snippet

### DIFF
--- a/docs/knowledge/KNOWLEDGE_INDEX.md
+++ b/docs/knowledge/KNOWLEDGE_INDEX.md
@@ -6,6 +6,7 @@ Scope: supporting docs for the 6 actions. Source of truth = Actions OpenAPI + Ro
 - policies/: routing, risk, session, idempotency, errors
 - workflows/: fast_lane, watchlist, memory
 - specs/: endpoint summaries (not full OpenAPI)
+- strategies/: TI strategy cards (source of truth)
 - tests/: golden prompts + pass criteria
 - scripts/: PowerShell 7 smokes
 - snippets/: reusable response text
@@ -30,5 +31,6 @@ Scope: supporting docs for the 6 actions. Source of truth = Actions OpenAPI + Ro
 - specs/journals_summary.md
 - specs/classifier_summary.md
 - specs/finnhub_summary.md
+- strategies/ti_strategy_cards.md
 - tests/golden_prompts.md
 - scripts/ps7_smoke.ps1

--- a/docs/knowledge/snippets/tone.md
+++ b/docs/knowledge/snippets/tone.md
@@ -1,5 +1,0 @@
-# Snippets: tone and guidance
-
-Next moves: “Generate trade preview”, “Submit via Fast lane”, “Add to watchlist”
-Pro move: “Stage exits at RTH using bracket”
-Blocked template: “Blocked by {rule}. Simplest fix: {action}”

--- a/docs/knowledge/strategies/ti_strategy_cards.md
+++ b/docs/knowledge/strategies/ti_strategy_cards.md
@@ -1,0 +1,6 @@
+# TI Strategy Cards — Source of truth
+
+> Paste the latest, full TI strategy cards content here. This file is authoritative for strategy logic.
+
+- Keep cards concise, versioned, and dated.
+- Do not duplicate card text in Instructions; reference this file.


### PR DESCRIPTION
## Summary
- add the strategies directory to the knowledge index and reference the TI strategy cards file
- remove the outdated tone snippet document
- create a placeholder TI strategy cards source-of-truth file under docs/knowledge/strategies

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d9b84df060832fa23bba59a8b93cb8