### PR TITLE
Add tone checks requirements to golden prompts documentation

### DIFF
--- a/docs/knowledge/tests/golden_prompts.md
+++ b/docs/knowledge/tests/golden_prompts.md
@@ -2,6 +2,13 @@
 
 Use Paper. Expect specific Router echoes or FastLaneResult bundles.
 
+## Tone checks (applies to all cases)
+- Answer-first line present.
+- `Next moves:` present with 1–3 items.
+- `Pro move:` one actionable line present.
+- When blocked: `What to watch:` present with one concrete step.
+- No fluff; concise.
+
 1) Fast lane RTH limit: AAPL buy; fresh TTL; expect submitted_order!=null; journal created.
 2) EXT bracket reject: user requests bracket in EXT; expect validation.ok=false; reason includes EXT rule; next moves suggest RTH bracket.
 3) Quote TTL stale: expect prompt to refresh Preflight; no order.


### PR DESCRIPTION
## Summary
- add tone consistency checklist to the golden prompts documentation for Paper router tests

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d9bd1e5444832fa725c4f9b31f8272